### PR TITLE
feat(db): Prisma schema with Neon driver adapter + AES-GCM crypto

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,297 @@
+// Prisma schema for oh-my-mcp
+// Run: pnpm db:generate
+// Migrate: pnpm db:migrate -- --name <label>
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+
+// ============================================================
+// better-auth core (generated-compatible fields)
+// ============================================================
+
+model User {
+  id            String    @id
+  name          String
+  email         String    @unique
+  emailVerified Boolean   @default(false)
+  image         String?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  sessions    Session[]
+  accounts    Account[]
+  members     Member[]
+  invitations Invitation[]
+
+  @@map("user")
+}
+
+model Session {
+  id        String   @id
+  expiresAt DateTime
+  token     String   @unique
+  ipAddress String?
+  userAgent String?
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // organization plugin
+  activeOrganizationId String?
+
+  @@index([userId])
+  @@map("session")
+}
+
+model Account {
+  id                    String    @id
+  accountId             String
+  providerId            String
+  userId                String
+  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  accessToken           String?
+  refreshToken          String?
+  idToken               String?
+  accessTokenExpiresAt  DateTime?
+  refreshTokenExpiresAt DateTime?
+  scope                 String?
+  password              String?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  @@unique([providerId, accountId])
+  @@index([userId])
+  @@map("account")
+}
+
+model Verification {
+  id         String   @id
+  identifier String
+  value      String
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([identifier])
+  @@map("verification")
+}
+
+// ============================================================
+// better-auth / organization plugin
+// ============================================================
+
+model Organization {
+  id        String   @id
+  name      String
+  slug      String   @unique
+  logo      String?
+  metadata  String?
+  createdAt DateTime @default(now())
+
+  members     Member[]
+  invitations Invitation[]
+  mcpServers  McpServer[]
+  openApiDocs OpenApiDoc[]
+  auditLogs   AuditLog[]
+
+  @@map("organization")
+}
+
+model Member {
+  id             String       @id
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  userId         String
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  role           String       @default("member")
+  createdAt      DateTime     @default(now())
+
+  @@unique([organizationId, userId])
+  @@index([userId])
+  @@map("member")
+}
+
+model Invitation {
+  id             String       @id
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  email          String
+  role           String?
+  status         String       @default("pending")
+  expiresAt      DateTime
+  inviterId      String
+  inviter        User         @relation(fields: [inviterId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId])
+  @@index([email])
+  @@map("invitation")
+}
+
+// ============================================================
+// oh-my-mcp domain
+// ============================================================
+
+enum McpVisibility {
+  PRIVATE
+  UNLISTED
+  PUBLIC
+}
+
+enum McpAuthType {
+  NONE
+  BEARER
+  HEADER
+  QUERY
+  BASIC
+}
+
+enum OpenApiSource {
+  UPLOAD
+  URL
+  PASTE
+}
+
+model OpenApiDoc {
+  id             String        @id @default(cuid())
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  title          String
+  version        String
+  source         OpenApiSource
+  sourceUrl      String?
+  hash           String        @db.VarChar(64)
+  rawJson        Json
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  mcpServers McpServer[]
+
+  @@unique([organizationId, hash])
+  @@index([organizationId])
+  @@map("openapi_doc")
+}
+
+model McpServer {
+  id             String        @id @default(cuid())
+  slug           String        @unique
+  organizationId String
+  organization   Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  openApiDocId   String
+  openApiDoc    OpenApiDoc    @relation(fields: [openApiDocId], references: [id], onDelete: Restrict)
+  name           String
+  description    String?
+  baseUrl        String
+  visibility     McpVisibility @default(PRIVATE)
+  // Arbitrary runtime config (headers, rate limits, etc.)
+  config         Json          @default("{}")
+  createdById    String
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  tools       McpTool[]
+  apiKeys     McpApiKey[]
+  accessTokens McpAccessToken[]
+  logs        McpCallLog[]
+
+  @@index([organizationId])
+  @@map("mcp_server")
+}
+
+model McpTool {
+  id           String  @id @default(cuid())
+  serverId     String
+  server       McpServer @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  name         String
+  operationId  String?
+  method       String
+  path         String
+  summary      String?
+  description  String?
+  inputSchema  Json
+  outputSchema Json?
+  // Instructions for mapping tool args to HTTP request (path/query/header/body).
+  wire         Json
+  securityKeys String[] @default([])
+  enabled      Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([serverId, name])
+  @@index([serverId])
+  @@map("mcp_tool")
+}
+
+// Outbound credentials used to call the upstream API.
+// `secretCipher` is AES-GCM(iv || ciphertext || authTag), base64url.
+model McpApiKey {
+  id           String     @id @default(cuid())
+  serverId     String
+  server       McpServer  @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  name         String
+  type         McpAuthType
+  // For HEADER/QUERY: the param name. Null for BEARER/BASIC.
+  paramName    String?
+  // Marks which OpenAPI security scheme name this fulfils.
+  schemeKey    String?
+  secretCipher String
+  createdAt    DateTime   @default(now())
+
+  @@index([serverId])
+  @@map("mcp_api_key")
+}
+
+// Inbound tokens clients use to reach a private MCP server.
+model McpAccessToken {
+  id        String    @id @default(cuid())
+  serverId  String
+  server    McpServer @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  name      String
+  // SHA-256 hex of the raw token. Raw token is shown once on creation.
+  tokenHash String    @unique
+  // Short prefix to display ("omm_abc…").
+  prefix    String
+  lastUsedAt DateTime?
+  expiresAt DateTime?
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([serverId])
+  @@map("mcp_access_token")
+}
+
+model McpCallLog {
+  id        String   @id @default(cuid())
+  serverId  String
+  server    McpServer @relation(fields: [serverId], references: [id], onDelete: Cascade)
+  toolName  String
+  status    Int
+  latencyMs Int
+  errorCode String?
+  createdAt DateTime @default(now())
+
+  @@index([serverId, createdAt])
+  @@map("mcp_call_log")
+}
+
+model AuditLog {
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  actorUserId    String?
+  action         String
+  targetType     String?
+  targetId       String?
+  metadata       Json?
+  createdAt      DateTime     @default(now())
+
+  @@index([organizationId, createdAt])
+  @@map("audit_log")
+}

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,102 @@
+/**
+ * AES-GCM helpers that work in both Node.js 20+ and the workerd runtime via
+ * the Web Crypto API (`globalThis.crypto.subtle`).
+ *
+ * Secrets are encoded as `base64url(iv || ciphertext_with_tag)`. Tokens are
+ * hashed with SHA-256 hex.
+ */
+
+const ALG = "AES-GCM";
+const IV_BYTES = 12;
+
+function b64urlEncode(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function toBufferSource(u8: Uint8Array): ArrayBuffer {
+  const buf = new ArrayBuffer(u8.byteLength);
+  new Uint8Array(buf).set(u8);
+  return buf;
+}
+
+async function importKey(encryptionKey: string): Promise<CryptoKey> {
+  const raw = b64urlDecode(encryptionKey.replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_"));
+  if (raw.byteLength !== 32) {
+    throw new Error("ENCRYPTION_KEY must decode to 32 bytes (base64 / base64url).");
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    toBufferSource(raw),
+    { name: ALG },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+export async function encryptSecret(plaintext: string, encryptionKey: string): Promise<string> {
+  const key = await importKey(encryptionKey);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const enc = new TextEncoder().encode(plaintext);
+  const ct = await crypto.subtle.encrypt(
+    { name: ALG, iv: toBufferSource(iv) },
+    key,
+    toBufferSource(enc)
+  );
+  const out = new Uint8Array(iv.byteLength + ct.byteLength);
+  out.set(iv, 0);
+  out.set(new Uint8Array(ct), iv.byteLength);
+  return b64urlEncode(out);
+}
+
+export async function decryptSecret(cipher: string, encryptionKey: string): Promise<string> {
+  const key = await importKey(encryptionKey);
+  const raw = b64urlDecode(cipher);
+  if (raw.byteLength < IV_BYTES + 16) {
+    throw new Error("Ciphertext too short.");
+  }
+  const iv = raw.slice(0, IV_BYTES);
+  const ct = raw.slice(IV_BYTES);
+  const pt = await crypto.subtle.decrypt(
+    { name: ALG, iv: toBufferSource(iv) },
+    key,
+    toBufferSource(ct)
+  );
+  return new TextDecoder().decode(pt);
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    toBufferSource(new TextEncoder().encode(input))
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function randomToken(prefix = "omm"): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return `${prefix}_${b64urlEncode(bytes)}`;
+}
+
+export function tokenPrefix(raw: string): string {
+  return raw.slice(0, 12);
+}
+
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,55 @@
+import { PrismaClient } from "@prisma/client";
+import { PrismaNeon } from "@prisma/adapter-neon";
+
+/**
+ * Prisma client factory.
+ *
+ * On Cloudflare Workers we MUST create a fresh client per request because
+ * connections from `@neondatabase/serverless` cannot be shared across
+ * invocations. In Node.js (local `next dev`) we keep a singleton keyed on the
+ * connection string to survive HMR without exhausting the pool.
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __prisma_cache__: Map<string, PrismaClient> | undefined;
+}
+
+function createClient(connectionString: string): PrismaClient {
+  const adapter = new PrismaNeon({ connectionString });
+  return new PrismaClient({ adapter });
+}
+
+function isNodeLongLived(): boolean {
+  return (
+    typeof process !== "undefined" &&
+    typeof process.versions?.node === "string" &&
+    process.env.NEXT_RUNTIME !== "edge" &&
+    !(globalThis as { WorkerGlobalScope?: unknown }).WorkerGlobalScope
+  );
+}
+
+/**
+ * Returns a Prisma client bound to the given (or env-derived) connection
+ * string. Safe to call inside request handlers — the Worker path always
+ * creates a fresh client.
+ */
+export function getDb(connectionString?: string): PrismaClient {
+  const url = connectionString ?? process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL is not set — configure a Neon pooled connection string."
+    );
+  }
+
+  if (isNodeLongLived() && process.env.NODE_ENV !== "production") {
+    globalThis.__prisma_cache__ ??= new Map<string, PrismaClient>();
+    const existing = globalThis.__prisma_cache__.get(url);
+    if (existing) return existing;
+    const client = createClient(url);
+    globalThis.__prisma_cache__.set(url, client);
+    return client;
+  }
+
+  return createClient(url);
+}


### PR DESCRIPTION
Closes #5

Drops in the full data model and secrets helpers.

- `prisma/schema.prisma`: better-auth core + organization plugin + full MCP domain
- `src/lib/db.ts`: PrismaClient using `@prisma/adapter-neon` (serverless-safe)
- `src/lib/crypto.ts`: AES-256-GCM + SHA-256 helpers for upstream creds & access tokens