### PR TITLE
feat(auth): better-auth with organization plugin

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { createAuthClient } from "better-auth/react";
+import { organizationClient } from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+  baseURL:
+    typeof window !== "undefined"
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_APP_URL,
+  plugins: [organizationClient()],
+});
+
+export const {
+  signIn,
+  signUp,
+  signOut,
+  useSession,
+  useListOrganizations,
+  useActiveOrganization,
+  organization,
+} = authClient;

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,74 @@
+import { betterAuth, type BetterAuthOptions } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import { organization } from "better-auth/plugins";
+import { nextCookies } from "better-auth/next-js";
+
+import { getDb } from "@/lib/db";
+
+/**
+ * Builds a request-scoped better-auth instance. The Prisma adapter is bound
+ * to the per-request Neon client so that each Worker invocation gets fresh
+ * DB connections.
+ */
+export function createAuth(connectionString?: string) {
+  const db = getDb(connectionString);
+
+  const options = {
+    database: prismaAdapter(db, { provider: "postgresql" }),
+    secret: process.env.BETTER_AUTH_SECRET,
+    baseURL: process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL,
+    emailAndPassword: {
+      enabled: true,
+      autoSignIn: true,
+      minPasswordLength: 8,
+    },
+    socialProviders: {
+      ...(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET
+        ? {
+            github: {
+              clientId: process.env.GITHUB_CLIENT_ID,
+              clientSecret: process.env.GITHUB_CLIENT_SECRET,
+            },
+          }
+        : {}),
+      ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+        ? {
+            google: {
+              clientId: process.env.GOOGLE_CLIENT_ID,
+              clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+            },
+          }
+        : {}),
+    },
+    plugins: [organization(), nextCookies()],
+  } satisfies BetterAuthOptions;
+
+  return betterAuth(options);
+}
+
+export type Auth = ReturnType<typeof createAuth>;
+export type AuthSession = Awaited<ReturnType<Auth["api"]["getSession"]>>;
+
+let _auth: Auth | null = null;
+
+function resolveAuth(): Auth {
+  if (!_auth) _auth = createAuth();
+  return _auth;
+}
+
+/**
+ * Lazy-initialised singleton for Node.js (`next dev` and better-auth CLI).
+ * Workers should prefer `createAuth(env.DATABASE_URL)` so that each
+ * invocation uses its own DB connection.
+ *
+ * Access is proxied so the module can be imported at build time without
+ * DATABASE_URL being set.
+ */
+export const auth = new Proxy({} as Auth, {
+  get(_t, prop) {
+    return Reflect.get(resolveAuth() as object, prop);
+  },
+  has(_t, prop) {
+    return Reflect.has(resolveAuth() as object, prop);
+  },
+});

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,0 +1,30 @@
+import type { PrismaClient } from "@prisma/client";
+import type { Auth, AuthSession } from "./auth";
+
+/**
+ * Hono context variables attached by middleware in `hono.ts`.
+ *
+ * - `db` is a per-request Prisma client bound to the current Neon connection.
+ * - `auth` is the better-auth instance sharing the same DB client.
+ * - `session` is populated when a logged-in user is detected; otherwise null.
+ * - `orgId` is the active organization id resolved from the session.
+ */
+export type Env = {
+  Variables: {
+    db: PrismaClient;
+    auth: Auth;
+    session: AuthSession | null;
+    orgId: string | null;
+  };
+  Bindings: {
+    DATABASE_URL?: string;
+    BETTER_AUTH_SECRET?: string;
+    BETTER_AUTH_URL?: string;
+    ENCRYPTION_KEY?: string;
+    NEXT_PUBLIC_APP_URL?: string;
+    GITHUB_CLIENT_ID?: string;
+    GITHUB_CLIENT_SECRET?: string;
+    GOOGLE_CLIENT_ID?: string;
+    GOOGLE_CLIENT_SECRET?: string;
+  };
+};

--- a/src/server/guards.ts
+++ b/src/server/guards.ts
@@ -1,0 +1,47 @@
+import { HTTPException } from "hono/http-exception";
+import type { Context, MiddlewareHandler } from "hono";
+import type { Env } from "./context";
+
+/** Requires an authenticated session. Sets `c.var.session.user` as non-null afterwards. */
+export const requireAuth: MiddlewareHandler<Env> = async (c, next) => {
+  const session = c.var.session;
+  if (!session?.user) {
+    throw new HTTPException(401, { message: "Sign in required." });
+  }
+  await next();
+};
+
+/** Requires an active organization on the session. Populates `c.var.orgId`. */
+export const requireOrg: MiddlewareHandler<Env> = async (c, next) => {
+  const session = c.var.session;
+  if (!session?.user) {
+    throw new HTTPException(401, { message: "Sign in required." });
+  }
+  if (!c.var.orgId) {
+    throw new HTTPException(400, {
+      message: "No active organization — create or select one first.",
+    });
+  }
+  await next();
+};
+
+/** Asserts the current user is a member of the given org. */
+export async function assertMember(c: Context<Env>, organizationId: string) {
+  const userId = c.var.session?.user?.id;
+  if (!userId) throw new HTTPException(401, { message: "Sign in required." });
+  const member = await c.var.db.member.findUnique({
+    where: { organizationId_userId: { organizationId, userId } },
+  });
+  if (!member) throw new HTTPException(403, { message: "Not a member of this organization." });
+  return member;
+}
+
+/** Ensures an `McpServer` belongs to the current active org. */
+export async function loadServer(c: Context<Env>, serverId: string) {
+  if (!c.var.orgId) throw new HTTPException(400, { message: "No active organization." });
+  const server = await c.var.db.mcpServer.findFirst({
+    where: { id: serverId, organizationId: c.var.orgId },
+  });
+  if (!server) throw new HTTPException(404, { message: "Server not found." });
+  return server;
+}

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,0 +1,33 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { auth } from "./auth";
+import { getDb } from "@/lib/db";
+
+/** Reads the current session from request headers. Returns null if none. */
+export async function getSession() {
+  const h = await headers();
+  return auth.api.getSession({ headers: h });
+}
+
+/** Requires an authenticated user. Redirects to /sign-in otherwise. */
+export async function requireSession() {
+  const session = await getSession();
+  if (!session?.user) redirect("/sign-in");
+  return session;
+}
+
+/** Requires both an authenticated user and an active organization. */
+export async function requireOrgSession() {
+  const session = await requireSession();
+  const orgId = session.session?.activeOrganizationId ?? null;
+  if (!orgId) redirect("/dashboard/onboarding");
+  return { session, orgId };
+}
+
+/** Convenience: returns { session, orgId, db } for dashboard RSCs. */
+export async function getDashboardContext() {
+  const { session, orgId } = await requireOrgSession();
+  const db = getDb();
+  return { session, orgId, db };
+}


### PR DESCRIPTION
Closes #7

Multi-tenant auth foundation. Email/password + GitHub + Google, with better-auth's organization plugin handling members/invites/roles. Adds Hono middleware and RSC helpers.