### PR TITLE
feat(api): Hono backend, typed RPC client, OpenAPI compiler

### DIFF
--- a/app/api/[[...route]]/route.ts
+++ b/app/api/[[...route]]/route.ts
@@ -1,0 +1,13 @@
+import { handle } from "hono/vercel";
+import { app } from "@/server/hono";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PUT = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
+export const OPTIONS = handle(app);
+export const HEAD = handle(app);

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,0 +1,28 @@
+import { hc } from "hono/client";
+import type { AppType } from "@/server/hono";
+
+/**
+ * Typed Hono RPC client. Usage:
+ *
+ *   const { data } = await api.me.$get().then((r) => r.json());
+ */
+export function getRpc(baseUrl?: string) {
+  const origin =
+    baseUrl ??
+    (typeof window !== "undefined"
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000");
+  // The Hono app is mounted with basePath("/api"), so we pass the bare origin
+  // here — `hc` already folds the basePath into the client tree.
+  return hc<AppType>(origin, {
+    fetch: ((input: RequestInfo | URL, init?: RequestInit) =>
+      fetch(input, {
+        ...init,
+        // Always include cookies for same-origin calls (auth session).
+        credentials: "include",
+      })) as typeof fetch,
+  });
+}
+
+export const api = getRpc();
+export type Rpc = ReturnType<typeof getRpc>;

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+export const cuid = z.string().min(1);
+export const slug = z
+  .string()
+  .min(3, "At least 3 characters.")
+  .max(48, "Too long.")
+  .regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i, "Use letters, numbers, and hyphens.");
+
+export const visibilityEnum = z.enum(["PRIVATE", "UNLISTED", "PUBLIC"]);
+export const authTypeEnum = z.enum(["NONE", "BEARER", "HEADER", "QUERY", "BASIC"]);
+export const openApiSourceEnum = z.enum(["UPLOAD", "URL", "PASTE"]);
+
+// ---- MCP servers ----
+
+export const createServerSchema = z.object({
+  name: z.string().min(1).max(80),
+  slug: slug,
+  description: z.string().max(500).optional().nullable(),
+  baseUrl: z.string().url().optional().nullable(),
+  visibility: visibilityEnum.default("PRIVATE"),
+  openApiDocId: cuid,
+});
+
+export const updateServerSchema = z.object({
+  name: z.string().min(1).max(80).optional(),
+  slug: slug.optional(),
+  description: z.string().max(500).nullable().optional(),
+  baseUrl: z.string().url().nullable().optional(),
+  visibility: visibilityEnum.optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+
+// ---- OpenAPI ingest ----
+
+export const ingestFromUrlSchema = z.object({
+  url: z.string().url(),
+});
+
+export const ingestFromTextSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  // JSON or YAML text
+  content: z.string().min(10),
+  source: openApiSourceEnum.default("PASTE"),
+});
+
+// ---- Tools ----
+
+export const updateToolSchema = z.object({
+  enabled: z.boolean().optional(),
+  description: z.string().max(800).nullable().optional(),
+});
+
+// ---- API keys (upstream credentials) ----
+
+export const createApiKeySchema = z.object({
+  name: z.string().min(1).max(80),
+  type: authTypeEnum,
+  paramName: z.string().min(1).max(80).optional().nullable(),
+  schemeKey: z.string().max(80).optional().nullable(),
+  secret: z.string().min(1),
+});
+
+// ---- Access tokens (inbound, sent by MCP clients) ----
+
+export const createAccessTokenSchema = z.object({
+  name: z.string().min(1).max(80),
+  expiresAt: z.string().datetime().optional().nullable(),
+});
+
+// ---- Organizations ----
+
+export const createOrgSchema = z.object({
+  name: z.string().min(1).max(80),
+  slug: slug,
+});
+
+export const inviteMemberSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["owner", "admin", "member"]).default("member"),
+});
+
+export type CreateServerInput = z.infer<typeof createServerSchema>;
+export type UpdateServerInput = z.infer<typeof updateServerSchema>;
+export type IngestFromUrlInput = z.infer<typeof ingestFromUrlSchema>;
+export type IngestFromTextInput = z.infer<typeof ingestFromTextSchema>;
+export type UpdateToolInput = z.infer<typeof updateToolSchema>;
+export type CreateApiKeyInput = z.infer<typeof createApiKeySchema>;
+export type CreateAccessTokenInput = z.infer<typeof createAccessTokenSchema>;
+export type CreateOrgInput = z.infer<typeof createOrgSchema>;
+export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -1,0 +1,63 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { logger } from "hono/logger";
+
+import { getDb } from "@/lib/db";
+import { createAuth } from "./auth";
+import type { Env } from "./context";
+
+import { serversRouter } from "./routers/servers";
+import { openApiRouter } from "./routers/openapi";
+import { toolsRouter } from "./routers/tools";
+import { apiKeysRouter } from "./routers/api-keys";
+import { accessTokensRouter } from "./routers/access-tokens";
+import { orgsRouter } from "./routers/orgs";
+import { meRouter } from "./routers/me";
+
+/**
+ * Root Hono app. Routes are chained so that Hono's RPC client can derive
+ * the full `AppType`. Per-request Prisma + better-auth instances are
+ * attached in middleware.
+ */
+const base = new Hono<Env>()
+  .basePath("/api")
+  .use("*", logger())
+  .use("*", async (c, next) => {
+    const url = c.env.DATABASE_URL ?? process.env.DATABASE_URL;
+    const db = getDb(url);
+    const auth = createAuth(url);
+    c.set("db", db);
+    c.set("auth", auth);
+    await next();
+  })
+  // better-auth handles /api/auth/* (sign-in, sign-up, oauth, org plugin).
+  .on(["GET", "POST"], "/auth/*", (c) => c.var.auth.handler(c.req.raw))
+  .use("*", async (c, next) => {
+    if (c.req.path.startsWith("/api/auth")) return next();
+    const session = await c.var.auth.api.getSession({ headers: c.req.raw.headers });
+    c.set("session", session ?? null);
+    c.set("orgId", session?.session?.activeOrganizationId ?? null);
+    await next();
+  })
+  .get("/health", (c) => c.json({ ok: true }));
+
+const app = base
+  .route("/me", meRouter)
+  .route("/orgs", orgsRouter)
+  .route("/openapi", openApiRouter)
+  .route("/servers", serversRouter)
+  .route("/servers/:serverId/tools", toolsRouter)
+  .route("/servers/:serverId/api-keys", apiKeysRouter)
+  .route("/servers/:serverId/access-tokens", accessTokensRouter)
+  .onError((err, c) => {
+    if (err instanceof HTTPException) return err.getResponse();
+    console.error("[hono] unhandled", err);
+    return c.json(
+      { error: "internal_error", message: (err as Error)?.message ?? "Unknown error" },
+      500
+    );
+  })
+  .notFound((c) => c.json({ error: "not_found", path: c.req.path }, 404));
+
+export { app };
+export type AppType = typeof app;

--- a/src/server/mcp/fromOpenAPI.ts
+++ b/src/server/mcp/fromOpenAPI.ts
@@ -1,0 +1,255 @@
+/**
+ * OpenAPI → MCP tool compiler.
+ *
+ * Supports OpenAPI 3.0 and 3.1 JSON documents. Responsibilities:
+ * - Derives a `baseUrl` from `servers[0].url` if present.
+ * - For every operation, creates a normalized tool descriptor with:
+ *   - `name`: sanitized `operationId` or `METHOD_path` fallback.
+ *   - `inputSchema`: a single JSON Schema merging path, query, header params
+ *     and the JSON request body.
+ *   - `outputSchema`: JSON Schema for the 2xx response body when present.
+ *   - `securityKeys`: the names of security schemes the operation requires.
+ *
+ * This compiler does NOT dereference external `$ref`s — the caller is
+ * expected to pass in a fully dereferenced document. See
+ * `src/server/routers/openapi.ts` where that happens.
+ *
+ * All unknown extensions are ignored; the goal is a fast, pure-function
+ * transformation that runs safely inside a Cloudflare Worker.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface CompiledTool {
+  name: string;
+  operationId: string | null;
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+  path: string; // OpenAPI path template like /users/{id}
+  summary: string | null;
+  description: string | null;
+  /** JSON Schema for tool inputs. */
+  inputSchema: JsonSchema;
+  outputSchema: JsonSchema | null;
+  /** Names of referenced security schemes (maps to OpenAPI components.securitySchemes keys). */
+  securityKeys: string[];
+  /**
+   * Instructions for mapping tool inputs to the outbound HTTP request.
+   * Stored next to the schema so the executor doesn't need to re-parse
+   * the OpenAPI doc at runtime.
+   */
+  wire: {
+    path: Array<{ name: string }>;
+    query: Array<{ name: string; style?: string; explode?: boolean }>;
+    header: Array<{ name: string }>;
+    body:
+      | { kind: "json" }
+      | { kind: "form"; contentType: "application/x-www-form-urlencoded" }
+      | { kind: "none" };
+  };
+}
+
+export interface CompiledInfo {
+  title: string;
+  version: string;
+  baseUrl: string | null;
+  securitySchemes: Record<string, any>;
+}
+
+export interface CompileResult {
+  info: CompiledInfo;
+  tools: CompiledTool[];
+}
+
+type JsonSchema = Record<string, any>;
+
+const METHODS = [
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+] as const;
+
+export function compileOpenApiToTools(doc: unknown): CompileResult {
+  if (!doc || typeof doc !== "object") {
+    throw new Error("Invalid OpenAPI document: not an object.");
+  }
+  const d = doc as any;
+
+  const info: CompiledInfo = {
+    title: d.info?.title ?? "Untitled API",
+    version: d.info?.version ?? "1.0.0",
+    baseUrl: pickBaseUrl(d.servers),
+    securitySchemes: d.components?.securitySchemes ?? {},
+  };
+
+  const tools: CompiledTool[] = [];
+  const used = new Set<string>();
+
+  const paths = (d.paths ?? {}) as Record<string, any>;
+  for (const [rawPath, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== "object") continue;
+    const pathLevelParams = (pathItem as any).parameters ?? [];
+
+    for (const method of METHODS) {
+      const op = (pathItem as any)[method];
+      if (!op || typeof op !== "object") continue;
+
+      const merged = mergeParams(pathLevelParams, op.parameters ?? []);
+      const name = uniqueName(
+        sanitizeName(op.operationId ?? `${method}_${rawPath}`),
+        used
+      );
+      used.add(name);
+
+      const input = buildInputSchema(merged, op.requestBody);
+      const output = buildOutputSchema(op.responses);
+
+      const securityKeys = extractSecurityKeys(op.security ?? d.security ?? []);
+
+      tools.push({
+        name,
+        operationId: op.operationId ?? null,
+        method: method.toUpperCase() as CompiledTool["method"],
+        path: rawPath,
+        summary: op.summary ?? null,
+        description: op.description ?? null,
+        inputSchema: input.schema,
+        outputSchema: output,
+        securityKeys,
+        wire: input.wire,
+      });
+    }
+  }
+
+  return { info, tools };
+}
+
+// ---- Internals ----
+
+function pickBaseUrl(servers: any): string | null {
+  if (!Array.isArray(servers) || servers.length === 0) return null;
+  const raw = servers[0]?.url;
+  if (typeof raw !== "string") return null;
+  // Strip trailing slash; leave templated vars alone.
+  return raw.replace(/\/$/, "");
+}
+
+function mergeParams(pathLevel: any[], opLevel: any[]): any[] {
+  const byKey = new Map<string, any>();
+  for (const p of pathLevel) byKey.set(`${p.in}:${p.name}`, p);
+  for (const p of opLevel) byKey.set(`${p.in}:${p.name}`, p);
+  return Array.from(byKey.values());
+}
+
+function sanitizeName(s: string): string {
+  return s
+    .replace(/[^\w]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 64)
+    .toLowerCase();
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  if (!used.has(base)) return base;
+  let i = 2;
+  while (used.has(`${base}_${i}`)) i++;
+  return `${base}_${i}`;
+}
+
+function buildInputSchema(
+  params: any[],
+  requestBody: any
+): { schema: JsonSchema; wire: CompiledTool["wire"] } {
+  const props: Record<string, JsonSchema> = {};
+  const required: string[] = [];
+  const wire: CompiledTool["wire"] = {
+    path: [],
+    query: [],
+    header: [],
+    body: { kind: "none" },
+  };
+
+  for (const p of params) {
+    if (!p || typeof p !== "object") continue;
+    const schema: JsonSchema = { ...(p.schema ?? {}) };
+    if (p.description && !schema.description) schema.description = p.description;
+    if (p.example !== undefined && schema.examples === undefined) {
+      schema.examples = [p.example];
+    }
+    switch (p.in) {
+      case "path":
+        wire.path.push({ name: p.name });
+        props[p.name] = schema;
+        required.push(p.name);
+        break;
+      case "query":
+        wire.query.push({ name: p.name, style: p.style, explode: p.explode });
+        props[p.name] = schema;
+        if (p.required) required.push(p.name);
+        break;
+      case "header": {
+        // Avoid colliding with transport auth; skip well-known ones.
+        const reserved = new Set(["authorization", "cookie", "content-type"]);
+        if (!reserved.has(String(p.name).toLowerCase())) {
+          wire.header.push({ name: p.name });
+          props[p.name] = schema;
+          if (p.required) required.push(p.name);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (requestBody && typeof requestBody === "object") {
+    const content = requestBody.content ?? {};
+    const json = content["application/json"];
+    const form = content["application/x-www-form-urlencoded"];
+    if (json?.schema) {
+      props.body = json.schema;
+      if (requestBody.required) required.push("body");
+      wire.body = { kind: "json" };
+    } else if (form?.schema) {
+      props.body = form.schema;
+      if (requestBody.required) required.push("body");
+      wire.body = {
+        kind: "form",
+        contentType: "application/x-www-form-urlencoded",
+      };
+    }
+  }
+
+  const schema: JsonSchema = {
+    type: "object",
+    properties: props,
+    ...(required.length ? { required: Array.from(new Set(required)) } : {}),
+    additionalProperties: false,
+  };
+  return { schema, wire };
+}
+
+function buildOutputSchema(responses: any): JsonSchema | null {
+  if (!responses || typeof responses !== "object") return null;
+  const keys = Object.keys(responses);
+  const successKey =
+    keys.find((k) => k.startsWith("2")) ?? (responses.default ? "default" : null);
+  if (!successKey) return null;
+  const resp = responses[successKey];
+  const content = resp?.content ?? {};
+  const json = content["application/json"];
+  return (json?.schema as JsonSchema) ?? null;
+}
+
+function extractSecurityKeys(security: any[]): string[] {
+  if (!Array.isArray(security)) return [];
+  const keys = new Set<string>();
+  for (const entry of security) {
+    if (!entry || typeof entry !== "object") continue;
+    for (const k of Object.keys(entry)) keys.add(k);
+  }
+  return Array.from(keys);
+}

--- a/src/server/mcp/parseOpenApi.ts
+++ b/src/server/mcp/parseOpenApi.ts
@@ -1,0 +1,123 @@
+/**
+ * Parse + dereference an OpenAPI document from a string.
+ *
+ * We keep this Worker-friendly: dereferencing is done in-memory on the raw
+ * JSON using a small, self-contained `$ref` resolver so we don't pull in
+ * Node-only validators. Remote `$ref`s are fetched via `fetch()` which works
+ * in both Node and workerd.
+ *
+ * This is intentionally lenient — we do not strictly validate the document.
+ * Invalid or partial specs will still produce a best-effort tool list; the
+ * caller can then surface validation messages in the UI.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { HTTPException } from "hono/http-exception";
+
+/** Parses text (JSON or YAML) into a JSON object, then dereferences $refs. */
+export async function parseOpenApi(text: string): Promise<unknown> {
+  const parsed = tryParse(text);
+  if (!parsed || typeof parsed !== "object") {
+    throw new HTTPException(400, { message: "OpenAPI document is not a valid object." });
+  }
+  if (!(parsed as any).openapi && !(parsed as any).swagger) {
+    throw new HTTPException(400, { message: "Missing `openapi` or `swagger` field." });
+  }
+  if ((parsed as any).swagger && !(parsed as any).openapi) {
+    throw new HTTPException(400, {
+      message:
+        "Swagger 2.0 documents are not yet supported — please convert to OpenAPI 3.x first.",
+    });
+  }
+  const deref = await dereference(parsed);
+  return deref;
+}
+
+function tryParse(text: string): unknown {
+  // JSON first (fast path).
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      /* fall through to YAML */
+    }
+  }
+  // Minimal YAML support: only what's necessary for common OpenAPI specs.
+  // We avoid bundling a full YAML parser in the Worker. For JSON-only specs
+  // this branch is never hit; for YAML, the user can paste JSON or the ingest
+  // route can translate upstream. For now, reject gracefully.
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    throw new HTTPException(400, {
+      message:
+        "Could not parse OpenAPI document. Please provide JSON (YAML support is coming soon).",
+    });
+  }
+}
+
+// ---- In-memory $ref dereferencer ----
+
+async function dereference(root: unknown): Promise<unknown> {
+  const rootObj = root as any;
+  const seen = new WeakSet<object>();
+
+  async function resolve(node: any): Promise<any> {
+    if (node === null || typeof node !== "object") return node;
+    if (seen.has(node)) return node;
+    seen.add(node);
+
+    if (typeof node.$ref === "string") {
+      const resolved = await resolveRef(node.$ref, rootObj);
+      // Merge sibling fields (allowed in OpenAPI 3.1) so that `description`
+      // etc. still take effect.
+      const { $ref: _ignored, ...siblings } = node;
+      void _ignored;
+      const merged = typeof resolved === "object" && resolved
+        ? { ...(resolved as object), ...siblings }
+        : resolved;
+      return await resolve(merged);
+    }
+
+    if (Array.isArray(node)) {
+      for (let i = 0; i < node.length; i++) node[i] = await resolve(node[i]);
+      return node;
+    }
+
+    for (const key of Object.keys(node)) {
+      node[key] = await resolve(node[key]);
+    }
+    return node;
+  }
+
+  return await resolve(rootObj);
+}
+
+async function resolveRef(ref: string, root: any): Promise<unknown> {
+  if (ref.startsWith("#/")) {
+    return resolvePointer(root, ref.slice(2));
+  }
+  // External ref — fetch and resolve fragment.
+  const [urlPart, fragment] = ref.split("#");
+  const res = await fetch(urlPart);
+  if (!res.ok) {
+    throw new HTTPException(400, {
+      message: `Could not fetch external $ref ${urlPart}: ${res.status}`,
+    });
+  }
+  const external = await res.json();
+  return fragment ? resolvePointer(external, fragment.replace(/^\//, "")) : external;
+}
+
+function resolvePointer(obj: any, pointer: string): unknown {
+  if (!pointer) return obj;
+  const parts = pointer.split("/").map((p) => p.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let cur: any = obj;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}

--- a/src/server/routers/access-tokens.ts
+++ b/src/server/routers/access-tokens.ts
@@ -1,0 +1,74 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+
+import type { Env } from "../context";
+import { requireOrg, loadServer } from "../guards";
+import { createAccessTokenSchema } from "@/lib/schemas";
+import { randomToken, sha256Hex, tokenPrefix } from "@/lib/crypto";
+
+/**
+ * Inbound tokens that MCP clients present to reach a private server.
+ * The raw token is shown exactly once on creation; thereafter we only store
+ * a SHA-256 hash.
+ */
+export const accessTokensRouter = new Hono<Env>()
+  .use("*", requireOrg)
+
+  .get("/", async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const server = await loadServer(c, serverId);
+    const tokens = await c.var.db.mcpAccessToken.findMany({
+      where: { serverId: server.id },
+      select: {
+        id: true,
+        name: true,
+        prefix: true,
+        lastUsedAt: true,
+        expiresAt: true,
+        revokedAt: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    return c.json({ tokens });
+  })
+
+  .post("/", zValidator("json", createAccessTokenSchema), async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const server = await loadServer(c, serverId);
+    const body = c.req.valid("json");
+    const raw = randomToken("omm");
+    const tokenHash = await sha256Hex(raw);
+    const prefix = tokenPrefix(raw);
+    const created = await c.var.db.mcpAccessToken.create({
+      data: {
+        serverId: server.id,
+        name: body.name,
+        tokenHash,
+        prefix,
+        expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+      },
+      select: {
+        id: true,
+        name: true,
+        prefix: true,
+        expiresAt: true,
+        createdAt: true,
+      },
+    });
+    // Only time the raw token is returned.
+    return c.json({ token: created, raw }, 201);
+  })
+
+  .post("/:tokenId/revoke", async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const tokenId = c.req.param("tokenId");
+    await loadServer(c, serverId);
+    await c.var.db.mcpAccessToken.update({
+      where: { id: tokenId },
+      data: { revokedAt: new Date() },
+    });
+    return c.json({ ok: true });
+  });
+
+export type AccessTokensRouter = typeof accessTokensRouter;

--- a/src/server/routers/api-keys.ts
+++ b/src/server/routers/api-keys.ts
@@ -1,0 +1,76 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { zValidator } from "@hono/zod-validator";
+
+import type { Env } from "../context";
+import { requireOrg, loadServer } from "../guards";
+import { createApiKeySchema } from "@/lib/schemas";
+import { encryptSecret } from "@/lib/crypto";
+
+/**
+ * Upstream credentials for the MCP executor — bearer tokens, header/query
+ * API keys, or basic auth username:password pairs. `secret` is encrypted
+ * with AES-GCM using `ENCRYPTION_KEY` before storage and never returned.
+ */
+export const apiKeysRouter = new Hono<Env>()
+  .use("*", requireOrg)
+
+  .get("/", async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const server = await loadServer(c, serverId);
+    const keys = await c.var.db.mcpApiKey.findMany({
+      where: { serverId: server.id },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        paramName: true,
+        schemeKey: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    return c.json({ keys });
+  })
+
+  .post("/", zValidator("json", createApiKeySchema), async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const server = await loadServer(c, serverId);
+    const body = c.req.valid("json");
+    const key = process.env.ENCRYPTION_KEY;
+    if (!key) {
+      throw new HTTPException(500, {
+        message: "ENCRYPTION_KEY is not configured on this deployment.",
+      });
+    }
+    const cipher = await encryptSecret(body.secret, key);
+    const created = await c.var.db.mcpApiKey.create({
+      data: {
+        serverId: server.id,
+        name: body.name,
+        type: body.type,
+        paramName: body.paramName ?? null,
+        schemeKey: body.schemeKey ?? null,
+        secretCipher: cipher,
+      },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        paramName: true,
+        schemeKey: true,
+        createdAt: true,
+      },
+    });
+    return c.json({ key: created }, 201);
+  })
+
+  .delete("/:keyId", async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const keyId = c.req.param("keyId");
+    await loadServer(c, serverId);
+    await c.var.db.mcpApiKey.delete({ where: { id: keyId } });
+    return c.json({ ok: true });
+  });
+
+export type ApiKeysRouter = typeof apiKeysRouter;

--- a/src/server/routers/me.ts
+++ b/src/server/routers/me.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import type { Env } from "../context";
+import { requireAuth } from "../guards";
+
+export const meRouter = new Hono<Env>()
+  .use("*", requireAuth)
+  .get("/", async (c) => {
+    const s = c.var.session!;
+    return c.json({
+      user: {
+        id: s.user.id,
+        name: s.user.name,
+        email: s.user.email,
+        image: s.user.image ?? null,
+      },
+      activeOrgId: c.var.orgId,
+    });
+  });
+
+export type MeRouter = typeof meRouter;

--- a/src/server/routers/openapi.ts
+++ b/src/server/routers/openapi.ts
@@ -1,0 +1,142 @@
+import { Hono, type Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { zValidator } from "@hono/zod-validator";
+import { Prisma } from "@prisma/client";
+
+import type { Env } from "../context";
+import { requireOrg } from "../guards";
+import { ingestFromUrlSchema, ingestFromTextSchema } from "@/lib/schemas";
+import { sha256Hex } from "@/lib/crypto";
+import { parseOpenApi } from "@/server/mcp/parseOpenApi";
+import { compileOpenApiToTools } from "@/server/mcp/fromOpenAPI";
+
+/**
+ * OpenAPI ingest endpoints. Accepts a URL, a pasted document (JSON or YAML),
+ * or a multipart file upload. Parses, validates, and persists the dereferenced
+ * document. Returns a summary (tool count, title, version) plus the generated
+ * `OpenApiDoc` id which is passed to `POST /servers` to materialize a server.
+ */
+export const openApiRouter = new Hono<Env>()
+  .use("*", requireOrg)
+
+  .get("/", async (c) => {
+    const docs = await c.var.db.openApiDoc.findMany({
+      where: { organizationId: c.var.orgId! },
+      select: {
+        id: true,
+        title: true,
+        version: true,
+        source: true,
+        sourceUrl: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    return c.json({ docs });
+  })
+
+  .post("/from-url", zValidator("json", ingestFromUrlSchema), async (c) => {
+    const { url } = c.req.valid("json");
+    const res = await fetch(url, { redirect: "follow" });
+    if (!res.ok) {
+      throw new HTTPException(400, {
+        message: `Failed to fetch OpenAPI from URL: ${res.status} ${res.statusText}`,
+      });
+    }
+    const text = await res.text();
+    const doc = await parseOpenApi(text);
+    return await persist(c, doc, { source: "URL", sourceUrl: url });
+  })
+
+  .post("/from-text", zValidator("json", ingestFromTextSchema), async (c) => {
+    const body = c.req.valid("json");
+    const doc = await parseOpenApi(body.content);
+    return await persist(c, doc, { source: body.source, sourceUrl: null });
+  })
+
+  .post("/from-file", async (c) => {
+    const form = await c.req.parseBody({ all: false });
+    const file = form["file"];
+    if (!(file instanceof File)) {
+      throw new HTTPException(400, { message: "Expected a file upload under `file`." });
+    }
+    const text = await file.text();
+    const doc = await parseOpenApi(text);
+    return await persist(c, doc, { source: "UPLOAD", sourceUrl: null });
+  })
+
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    const doc = await c.var.db.openApiDoc.findFirst({
+      where: { id, organizationId: c.var.orgId! },
+    });
+    if (!doc) throw new HTTPException(404, { message: "Not found." });
+    const preview = compileOpenApiToTools(doc.rawJson as unknown);
+    return c.json({
+      id: doc.id,
+      title: doc.title,
+      version: doc.version,
+      source: doc.source,
+      sourceUrl: doc.sourceUrl,
+      toolCount: preview.tools.length,
+      baseUrl: preview.info.baseUrl,
+    });
+  });
+
+async function persist(
+  c: Context<Env>,
+  doc: unknown,
+  meta: { source: "UPLOAD" | "URL" | "PASTE"; sourceUrl: string | null }
+) {
+  const normalized = JSON.stringify(doc);
+  const hash = await sha256Hex(normalized);
+  const compiled = compileOpenApiToTools(doc);
+  const orgId = c.var.orgId!;
+
+  try {
+    const created = await c.var.db.openApiDoc.create({
+      data: {
+        organizationId: orgId,
+        title: compiled.info.title,
+        version: compiled.info.version,
+        source: meta.source,
+        sourceUrl: meta.sourceUrl,
+        hash,
+        rawJson: doc as Prisma.InputJsonValue,
+      },
+    });
+    return c.json(
+      {
+        doc: {
+          id: created.id,
+          title: created.title,
+          version: created.version,
+          toolCount: compiled.tools.length,
+          baseUrl: compiled.info.baseUrl,
+        },
+      },
+      201
+    );
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      const existing = await c.var.db.openApiDoc.findUnique({
+        where: { organizationId_hash: { organizationId: orgId, hash } },
+      });
+      if (existing) {
+        return c.json({
+          doc: {
+            id: existing.id,
+            title: existing.title,
+            version: existing.version,
+            toolCount: compiled.tools.length,
+            baseUrl: compiled.info.baseUrl,
+          },
+          deduped: true,
+        });
+      }
+    }
+    throw err;
+  }
+}
+
+export type OpenApiRouter = typeof openApiRouter;

--- a/src/server/routers/orgs.ts
+++ b/src/server/routers/orgs.ts
@@ -1,0 +1,73 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { zValidator } from "@hono/zod-validator";
+
+import type { Env } from "../context";
+import { requireAuth } from "../guards";
+import { createOrgSchema, inviteMemberSchema } from "@/lib/schemas";
+
+export const orgsRouter = new Hono<Env>()
+  .use("*", requireAuth)
+
+  .get("/", async (c) => {
+    const userId = c.var.session!.user.id;
+    const memberships = await c.var.db.member.findMany({
+      where: { userId },
+      include: { organization: true },
+      orderBy: { createdAt: "asc" },
+    });
+    return c.json({
+      organizations: memberships.map((m) => ({
+        id: m.organization.id,
+        name: m.organization.name,
+        slug: m.organization.slug,
+        role: m.role,
+      })),
+      activeOrgId: c.var.orgId,
+    });
+  })
+
+  .post("/", zValidator("json", createOrgSchema), async (c) => {
+    const body = c.req.valid("json");
+    const res = await c.var.auth.api.createOrganization({
+      body: { name: body.name, slug: body.slug },
+      headers: c.req.raw.headers,
+    });
+    if (!res) throw new HTTPException(400, { message: "Could not create organization." });
+    return c.json({ organization: res }, 201);
+  })
+
+  .post("/:orgId/set-active", async (c) => {
+    const orgId = c.req.param("orgId");
+    await c.var.auth.api.setActiveOrganization({
+      body: { organizationId: orgId },
+      headers: c.req.raw.headers,
+    });
+    return c.json({ ok: true, orgId });
+  })
+
+  .get("/:orgId/members", async (c) => {
+    const orgId = c.req.param("orgId");
+    const members = await c.var.db.member.findMany({
+      where: { organizationId: orgId },
+      include: { user: { select: { id: true, name: true, email: true, image: true } } },
+      orderBy: { createdAt: "asc" },
+    });
+    return c.json({ members });
+  })
+
+  .post(
+    "/:orgId/invite",
+    zValidator("json", inviteMemberSchema),
+    async (c) => {
+      const orgId = c.req.param("orgId");
+      const body = c.req.valid("json");
+      const inv = await c.var.auth.api.createInvitation({
+        body: { email: body.email, role: body.role, organizationId: orgId },
+        headers: c.req.raw.headers,
+      });
+      return c.json({ invitation: inv }, 201);
+    }
+  );
+
+export type OrgsRouter = typeof orgsRouter;

--- a/src/server/routers/servers.ts
+++ b/src/server/routers/servers.ts
@@ -1,0 +1,136 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { zValidator } from "@hono/zod-validator";
+import { Prisma } from "@prisma/client";
+
+import type { Env } from "../context";
+import { requireOrg } from "../guards";
+import { createServerSchema, updateServerSchema } from "@/lib/schemas";
+import { compileOpenApiToTools } from "@/server/mcp/fromOpenAPI";
+
+export const serversRouter = new Hono<Env>()
+  .use("*", requireOrg)
+
+  .get("/", async (c) => {
+    const orgId = c.var.orgId!;
+    const servers = await c.var.db.mcpServer.findMany({
+      where: { organizationId: orgId },
+      include: {
+        _count: { select: { tools: true } },
+        openApiDoc: { select: { title: true, version: true } },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+    return c.json({ servers });
+  })
+
+  .post("/", zValidator("json", createServerSchema), async (c) => {
+    const body = c.req.valid("json");
+    const orgId = c.var.orgId!;
+    const userId = c.var.session!.user.id;
+
+    // Load the source doc so we know the upstream baseUrl fallback.
+    const doc = await c.var.db.openApiDoc.findFirst({
+      where: { id: body.openApiDocId, organizationId: orgId },
+    });
+    if (!doc) throw new HTTPException(404, { message: "OpenAPI document not found." });
+
+    const { tools, info } = compileOpenApiToTools(doc.rawJson as unknown);
+    const baseUrl = body.baseUrl ?? info.baseUrl ?? null;
+    if (!baseUrl) {
+      throw new HTTPException(400, {
+        message:
+          "No base URL supplied and none inferable from the OpenAPI servers[] array.",
+      });
+    }
+
+    try {
+      const created = await c.var.db.mcpServer.create({
+        data: {
+          name: body.name,
+          slug: body.slug,
+          description: body.description ?? null,
+          baseUrl,
+          visibility: body.visibility,
+          organizationId: orgId,
+          openApiDocId: doc.id,
+          createdById: userId,
+          tools: {
+            create: tools.map((t) => ({
+              name: t.name,
+              operationId: t.operationId ?? null,
+              method: t.method,
+              path: t.path,
+              summary: t.summary ?? null,
+              description: t.description ?? null,
+              inputSchema: t.inputSchema as unknown as Prisma.InputJsonValue,
+              outputSchema: (t.outputSchema ?? null) as Prisma.InputJsonValue,
+              wire: t.wire as unknown as Prisma.InputJsonValue,
+              securityKeys: t.securityKeys,
+              enabled: true,
+            })),
+          },
+        },
+        include: { _count: { select: { tools: true } } },
+      });
+      return c.json({ server: created }, 201);
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+        throw new HTTPException(409, { message: "Slug already taken." });
+      }
+      throw err;
+    }
+  })
+
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    const orgId = c.var.orgId!;
+    const server = await c.var.db.mcpServer.findFirst({
+      where: { id, organizationId: orgId },
+      include: {
+        openApiDoc: { select: { id: true, title: true, version: true } },
+        _count: { select: { tools: true, apiKeys: true, accessTokens: true } },
+      },
+    });
+    if (!server) throw new HTTPException(404, { message: "Server not found." });
+    return c.json({ server });
+  })
+
+  .patch("/:id", zValidator("json", updateServerSchema), async (c) => {
+    const id = c.req.param("id");
+    const orgId = c.var.orgId!;
+    const body = c.req.valid("json");
+    try {
+      const updated = await c.var.db.mcpServer.update({
+        where: { id, organizationId: orgId },
+        data: {
+          ...(body.name !== undefined ? { name: body.name } : {}),
+          ...(body.slug !== undefined ? { slug: body.slug } : {}),
+          ...(body.description !== undefined ? { description: body.description } : {}),
+          ...(body.baseUrl !== undefined ? { baseUrl: body.baseUrl ?? undefined } : {}),
+          ...(body.visibility !== undefined ? { visibility: body.visibility } : {}),
+          ...(body.config !== undefined
+            ? { config: body.config as Prisma.InputJsonValue }
+            : {}),
+        },
+      });
+      return c.json({ server: updated });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError) {
+        if (err.code === "P2002")
+          throw new HTTPException(409, { message: "Slug already taken." });
+        if (err.code === "P2025")
+          throw new HTTPException(404, { message: "Server not found." });
+      }
+      throw err;
+    }
+  })
+
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    const orgId = c.var.orgId!;
+    await c.var.db.mcpServer.delete({ where: { id, organizationId: orgId } });
+    return c.json({ ok: true });
+  });
+
+export type ServersRouter = typeof serversRouter;

--- a/src/server/routers/tools.ts
+++ b/src/server/routers/tools.ts
@@ -1,0 +1,52 @@
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { zValidator } from "@hono/zod-validator";
+
+import type { Env } from "../context";
+import { requireOrg, loadServer } from "../guards";
+import { updateToolSchema } from "@/lib/schemas";
+
+export const toolsRouter = new Hono<Env>()
+  .use("*", requireOrg)
+
+  .get("/", async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const server = await loadServer(c, serverId);
+    const tools = await c.var.db.mcpTool.findMany({
+      where: { serverId: server.id },
+      orderBy: { name: "asc" },
+    });
+    return c.json({ tools });
+  })
+
+  .get("/:toolId", async (c) => {
+    const serverId = c.req.param("serverId")!;
+    const toolId = c.req.param("toolId");
+    await loadServer(c, serverId);
+    const tool = await c.var.db.mcpTool.findFirst({
+      where: { id: toolId, serverId },
+    });
+    if (!tool) throw new HTTPException(404, { message: "Tool not found." });
+    return c.json({ tool });
+  })
+
+  .patch(
+    "/:toolId",
+    zValidator("json", updateToolSchema),
+    async (c) => {
+      const serverId = c.req.param("serverId")!;
+      const toolId = c.req.param("toolId");
+      await loadServer(c, serverId);
+      const body = c.req.valid("json");
+      const tool = await c.var.db.mcpTool.update({
+        where: { id: toolId },
+        data: {
+          ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+          ...(body.description !== undefined ? { description: body.description } : {}),
+        },
+      });
+      return c.json({ tool });
+    }
+  );
+
+export type ToolsRouter = typeof toolsRouter;


### PR DESCRIPTION
Closes #9

Adds the entire HTTP backend in one cohesive PR:

- Hono mounted at `app/api/[[...route]]` with chained routers for RPC typing
- Routers for me, orgs, servers, tools, api-keys, access-tokens, openapi
- Typed Hono RPC client (`src/lib/rpc.ts`)
- Shared Zod schemas (`src/lib/schemas/`)
- OpenAPI parser (JSON + `\$ref` resolver) + compiler that emits `McpTool` rows

Bigger than other PRs but intentionally atomic — routers and `hono.ts` can't land separately without temporarily breaking typecheck.