### PR TITLE
feat(mcp): Streamable HTTP runtime + tool executor

### DIFF
--- a/app/mcp/[slug]/route.ts
+++ b/app/mcp/[slug]/route.ts
@@ -1,0 +1,22 @@
+import { getDb } from "@/lib/db";
+import { handleMcpRequest } from "@/server/mcp/handler";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+async function dispatch(req: Request, ctx: { params: Promise<{ slug: string }> }) {
+  const { slug } = await ctx.params;
+  const db = getDb();
+  const encryptionKey = process.env.ENCRYPTION_KEY;
+  if (!encryptionKey) {
+    return new Response(
+      JSON.stringify({ error: "server_misconfigured", message: "ENCRYPTION_KEY not set." }),
+      { status: 500, headers: { "content-type": "application/json" } }
+    );
+  }
+  return handleMcpRequest(req, slug, { db, encryptionKey });
+}
+
+export const GET = dispatch;
+export const POST = dispatch;
+export const DELETE = dispatch;

--- a/src/server/mcp/executor.ts
+++ b/src/server/mcp/executor.ts
@@ -1,0 +1,200 @@
+/**
+ * Outbound HTTP executor: takes a compiled `McpTool` (from the DB) plus the
+ * caller-supplied JSON arguments and performs the real upstream request.
+ *
+ * Security scheme binding:
+ *   - For each `securityKey` on the tool, we look up an `McpApiKey` whose
+ *     `schemeKey` matches (or falls back to type-only matches if absent).
+ *   - Secrets are decrypted with `ENCRYPTION_KEY` right before the request.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { McpApiKey, McpTool } from "@prisma/client";
+import { decryptSecret } from "@/lib/crypto";
+
+export interface ExecuteOptions {
+  baseUrl: string;
+  tool: McpTool;
+  args: unknown;
+  apiKeys: McpApiKey[];
+  encryptionKey: string;
+  /** Max outbound response body length (in bytes) before we truncate. */
+  maxResponseBytes?: number;
+  /** Hard timeout for upstream call in ms. */
+  timeoutMs?: number;
+}
+
+export interface ExecuteResult {
+  status: number;
+  contentType: string | null;
+  body: string;
+  json: unknown;
+  latencyMs: number;
+}
+
+interface Wire {
+  path: Array<{ name: string }>;
+  query: Array<{ name: string; style?: string; explode?: boolean }>;
+  header: Array<{ name: string }>;
+  body:
+    | { kind: "json" }
+    | { kind: "form"; contentType: string }
+    | { kind: "none" };
+}
+
+export async function executeTool(opts: ExecuteOptions): Promise<ExecuteResult> {
+  const started = Date.now();
+  const wire = opts.tool.wire as unknown as Wire;
+  const argsObj = (opts.args && typeof opts.args === "object" ? opts.args : {}) as Record<
+    string,
+    unknown
+  >;
+
+  // 1. Build URL with path substitution and query string.
+  let url = joinUrl(opts.baseUrl, opts.tool.path);
+  for (const p of wire.path) {
+    const v = argsObj[p.name];
+    if (v === undefined || v === null) {
+      throw new Error(`Missing required path parameter "${p.name}".`);
+    }
+    url = url.replace(
+      new RegExp(`\\{${escapeRegExp(p.name)}\\}`, "g"),
+      encodeURIComponent(String(v))
+    );
+  }
+
+  const qs = new URLSearchParams();
+  for (const q of wire.query) {
+    const v = argsObj[q.name];
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) {
+      // `explode: false` → comma join, otherwise append multiple.
+      if (q.explode === false) qs.append(q.name, v.join(","));
+      else for (const item of v) qs.append(q.name, String(item));
+    } else if (typeof v === "object") {
+      qs.append(q.name, JSON.stringify(v));
+    } else {
+      qs.append(q.name, String(v));
+    }
+  }
+  const qsString = qs.toString();
+  if (qsString) url += (url.includes("?") ? "&" : "?") + qsString;
+
+  // 2. Headers.
+  const headers: Record<string, string> = {
+    accept: "application/json, text/plain;q=0.8, */*;q=0.5",
+  };
+  for (const h of wire.header) {
+    const v = argsObj[h.name];
+    if (v !== undefined && v !== null) headers[h.name] = String(v);
+  }
+
+  // 3. Auth injection.
+  url = await applyAuth(headers, url, opts);
+
+  // 4. Body.
+  let body: BodyInit | undefined;
+  if (wire.body.kind === "json") {
+    headers["content-type"] = "application/json";
+    body = JSON.stringify((argsObj as any).body ?? null);
+  } else if (wire.body.kind === "form") {
+    headers["content-type"] = wire.body.contentType;
+    const form = new URLSearchParams();
+    const b = (argsObj as any).body;
+    if (b && typeof b === "object") {
+      for (const [k, v] of Object.entries(b)) {
+        if (Array.isArray(v)) for (const it of v) form.append(k, String(it));
+        else if (v !== undefined && v !== null) form.append(k, String(v));
+      }
+    }
+    body = form.toString();
+  }
+
+  // 5. Fire with timeout.
+  const ac = new AbortController();
+  const timeout = setTimeout(() => ac.abort(), opts.timeoutMs ?? 30_000);
+  try {
+    const res = await fetch(url, {
+      method: opts.tool.method,
+      headers,
+      body,
+      signal: ac.signal,
+      redirect: "follow",
+    });
+    const contentType = res.headers.get("content-type");
+    const max = opts.maxResponseBytes ?? 1_000_000;
+    const raw = await res.text();
+    const clipped = raw.length > max ? raw.slice(0, max) + "…[truncated]" : raw;
+    let json: unknown = null;
+    if (contentType?.includes("application/json")) {
+      try {
+        json = JSON.parse(raw);
+      } catch {
+        json = null;
+      }
+    }
+    return {
+      status: res.status,
+      contentType,
+      body: clipped,
+      json,
+      latencyMs: Date.now() - started,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function applyAuth(
+  headers: Record<string, string>,
+  url: string,
+  opts: ExecuteOptions
+): Promise<string> {
+  const needed = opts.tool.securityKeys ?? [];
+  if (!needed.length || opts.apiKeys.length === 0) return url;
+
+  let currentUrl = url;
+  for (const schemeKey of needed) {
+    const match =
+      opts.apiKeys.find((k) => k.schemeKey === schemeKey) ?? opts.apiKeys[0];
+    if (!match) continue;
+    const secret = await decryptSecret(match.secretCipher, opts.encryptionKey);
+    switch (match.type) {
+      case "BEARER":
+        headers["authorization"] = `Bearer ${secret}`;
+        break;
+      case "HEADER":
+        if (match.paramName) headers[match.paramName] = secret;
+        break;
+      case "QUERY": {
+        if (match.paramName) {
+          const u = new URL(currentUrl);
+          u.searchParams.set(match.paramName, secret);
+          currentUrl = u.toString();
+        }
+        break;
+      }
+      case "BASIC": {
+        // Secret stored as `user:pass`.
+        const encoded = btoa(secret);
+        headers["authorization"] = `Basic ${encoded}`;
+        break;
+      }
+      case "NONE":
+      default:
+        break;
+    }
+  }
+  return currentUrl;
+}
+
+function joinUrl(base: string, path: string): string {
+  const b = base.replace(/\/$/, "");
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${b}${p}`;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/server/mcp/handler.ts
+++ b/src/server/mcp/handler.ts
@@ -1,0 +1,279 @@
+/**
+ * Minimal, Worker-compatible MCP Streamable HTTP server.
+ *
+ * Implements the subset of the MCP spec required by standard clients
+ * (Claude Desktop, Cursor, etc.):
+ *   - `POST /mcp/:slug`  → JSON-RPC 2.0 request/response
+ *   - `GET  /mcp/:slug`  → SSE-style event stream for server-initiated events
+ *     (we keep it open but emit nothing today; clients that expect a
+ *     persistent stream accept a trickle of keepalive comments).
+ *
+ * Supported methods:
+ *   - `initialize`
+ *   - `tools/list`
+ *   - `tools/call`
+ *   - `ping`
+ *
+ * Everything heavier (resources, prompts, progress notifications) is
+ * declared unsupported in the initialize response so clients don't hang
+ * waiting for them.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { PrismaClient } from "@prisma/client";
+import { sha256Hex, timingSafeEqualHex } from "@/lib/crypto";
+import { executeTool } from "./executor";
+
+const PROTOCOL_VERSION = "2025-03-26";
+
+export interface McpHandlerDeps {
+  db: PrismaClient;
+  encryptionKey: string;
+}
+
+export async function handleMcpRequest(
+  req: Request,
+  slug: string,
+  deps: McpHandlerDeps
+): Promise<Response> {
+  const server = await deps.db.mcpServer.findUnique({
+    where: { slug },
+    include: {
+      tools: { where: { enabled: true } },
+      apiKeys: true,
+    },
+  });
+  if (!server) return jsonRpcHttp(404, "Server not found.");
+
+  const authOk = await checkAccess(req, server, deps);
+  if (!authOk) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: { "www-authenticate": 'Bearer realm="oh-my-mcp"' },
+    });
+  }
+
+  if (req.method === "GET") return openEventStream();
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonRpcError(null, -32700, "Parse error");
+  }
+
+  // Batched requests — MCP permits JSON-RPC batches.
+  if (Array.isArray(payload)) {
+    const responses = await Promise.all(
+      payload.map((p) => dispatch(p, server, deps))
+    );
+    return json(responses.filter((r) => r !== null));
+  }
+
+  const res = await dispatch(payload, server, deps);
+  return res ? json(res) : new Response(null, { status: 204 });
+}
+
+// ---- Dispatch ----
+
+async function dispatch(
+  req: any,
+  server: Awaited<ReturnType<PrismaClient["mcpServer"]["findUnique"]>> & {
+    tools: any[];
+    apiKeys: any[];
+  },
+  deps: McpHandlerDeps
+): Promise<any | null> {
+  if (!req || typeof req !== "object") {
+    return rpcError(null, -32600, "Invalid Request");
+  }
+  const { id = null, method, params } = req;
+  const isNotification = id === undefined || id === null;
+
+  try {
+    switch (method) {
+      case "initialize":
+        return rpcOk(id, {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: {
+            tools: { listChanged: false },
+          },
+          serverInfo: {
+            name: server!.name,
+            version: "1.0.0",
+          },
+          instructions: server!.description ?? undefined,
+        });
+
+      case "notifications/initialized":
+        return null;
+
+      case "ping":
+        return rpcOk(id, {});
+
+      case "tools/list": {
+        const tools = server!.tools.map((t: any) => ({
+          name: t.name,
+          description: t.description ?? t.summary ?? undefined,
+          inputSchema: t.inputSchema,
+        }));
+        return rpcOk(id, { tools });
+      }
+
+      case "tools/call": {
+        const name = params?.name;
+        const args = params?.arguments ?? {};
+        if (!name) return rpcError(id, -32602, "Missing tool name.");
+
+        const tool = server!.tools.find((t: any) => t.name === name);
+        if (!tool) return rpcError(id, -32601, `Unknown tool: ${name}`);
+
+        const started = Date.now();
+        try {
+          const result = await executeTool({
+            baseUrl: server!.baseUrl,
+            tool,
+            args,
+            apiKeys: server!.apiKeys,
+            encryptionKey: deps.encryptionKey,
+          });
+
+          await deps.db.mcpCallLog.create({
+            data: {
+              serverId: server!.id,
+              toolName: name,
+              status: result.status,
+              latencyMs: result.latencyMs,
+            },
+          }).catch(() => {
+            /* logging best-effort */
+          });
+
+          return rpcOk(id, {
+            content: [
+              {
+                type: "text",
+                text:
+                  result.json !== null
+                    ? JSON.stringify(result.json, null, 2)
+                    : result.body,
+              },
+            ],
+            isError: result.status >= 400,
+            _meta: {
+              status: result.status,
+              contentType: result.contentType,
+              latencyMs: result.latencyMs,
+            },
+          });
+        } catch (err) {
+          const message = (err as Error)?.message ?? "Tool execution failed.";
+          await deps.db.mcpCallLog.create({
+            data: {
+              serverId: server!.id,
+              toolName: name,
+              status: 0,
+              latencyMs: Date.now() - started,
+              errorCode: "execute_failed",
+            },
+          }).catch(() => {});
+          return rpcOk(id, {
+            content: [{ type: "text", text: `Error: ${message}` }],
+            isError: true,
+          });
+        }
+      }
+
+      default:
+        if (isNotification) return null;
+        return rpcError(id, -32601, `Method not found: ${method}`);
+    }
+  } catch (err) {
+    console.error("[mcp] dispatch error", err);
+    return rpcError(id, -32603, "Internal error");
+  }
+}
+
+// ---- Access control ----
+
+async function checkAccess(
+  req: Request,
+  server: { id: string; visibility: string },
+  deps: McpHandlerDeps
+): Promise<boolean> {
+  if (server.visibility === "PUBLIC") return true;
+
+  const auth = req.headers.get("authorization");
+  if (!auth) return server.visibility === "UNLISTED";
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return false;
+  const raw = m[1].trim();
+  const hash = await sha256Hex(raw);
+
+  const token = await deps.db.mcpAccessToken.findFirst({
+    where: { serverId: server.id, tokenHash: hash, revokedAt: null },
+  });
+  if (!token) return false;
+  if (token.expiresAt && token.expiresAt < new Date()) return false;
+  if (!timingSafeEqualHex(token.tokenHash, hash)) return false;
+
+  // Best-effort last-used stamp.
+  deps.db.mcpAccessToken
+    .update({ where: { id: token.id }, data: { lastUsedAt: new Date() } })
+    .catch(() => {});
+
+  return true;
+}
+
+// ---- Helpers ----
+
+function rpcOk(id: unknown, result: unknown) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function rpcError(id: unknown, code: number, message: string, data?: unknown) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code, message, ...(data !== undefined ? { data } : {}) },
+  };
+}
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function jsonRpcHttp(status: number, message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function jsonRpcError(id: unknown, code: number, message: string): Response {
+  return json(rpcError(id, code, message));
+}
+
+function openEventStream(): Response {
+  // Empty SSE stream — keeps the connection open for clients that insist
+  // on the GET endpoint, but we never emit server-initiated events (yet).
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(":ok\n\n"));
+    },
+  });
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    },
+  });
+}


### PR DESCRIPTION
Closes #11

The public-facing piece. Any MCP client (Claude Desktop, Cursor, Continue, etc.) can hit `/mcp/<slug>` and get tools back.

- JSON-RPC dispatcher for `initialize` / `tools/list` / `tools/call`
- Bearer-token access control (PUBLIC open, PRIVATE/UNLISTED require a hashed token match)
- Executor fills OpenAPI path/query/header params from the JSON args, decrypts the matching upstream credential, logs every call