### PR TITLE
feat(dashboard): dashboard shell, servers CRUD, tools, tokens, org

### DIFF
--- a/app/(dashboard)/account/page.tsx
+++ b/app/(dashboard)/account/page.tsx
@@ -1,0 +1,39 @@
+import { getSession } from "@/server/session";
+import { redirect } from "next/navigation";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+export default async function AccountPage() {
+  const session = await getSession();
+  if (!session?.user) redirect("/sign-in");
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Account</h1>
+        <p className="text-sm text-muted-foreground">Profile and sign-in details.</p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Profile</CardTitle>
+          <CardDescription>Managed by your auth provider.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Name</span>
+            <span className="font-medium">{session.user.name}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Email</span>
+            <span className="font-medium">{session.user.email}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Email verified</span>
+            <span className="font-medium">{session.user.emailVerified ? "yes" : "no"}</span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/onboarding/page.tsx
+++ b/app/(dashboard)/dashboard/onboarding/page.tsx
@@ -1,0 +1,22 @@
+import { OnboardingForm } from "@/components/dashboard/onboarding-form";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+export default function OnboardingPage() {
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md items-center">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Create your first organization</CardTitle>
+          <CardDescription>
+            Your MCP servers and credentials live inside organizations.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <OnboardingForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import { ArrowRight, Stack, Users, Key, Lightning } from "@phosphor-icons/react/dist/ssr";
+
+import { getDashboardContext } from "@/server/session";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+export default async function OverviewPage() {
+  const { db, orgId } = await getDashboardContext();
+
+  const [serverCount, toolCount, keyCount, tokenCount, recentServers] = await Promise.all([
+    db.mcpServer.count({ where: { organizationId: orgId } }),
+    db.mcpTool.count({ where: { server: { organizationId: orgId } } }),
+    db.mcpApiKey.count({ where: { server: { organizationId: orgId } } }),
+    db.mcpAccessToken.count({ where: { server: { organizationId: orgId } } }),
+    db.mcpServer.findMany({
+      where: { organizationId: orgId },
+      orderBy: { updatedAt: "desc" },
+      take: 5,
+      include: {
+        _count: { select: { tools: true } },
+        openApiDoc: { select: { title: true, version: true } },
+      },
+    }),
+  ]);
+
+  const stats = [
+    { label: "Servers", value: serverCount, icon: Stack },
+    { label: "Tools", value: toolCount, icon: Lightning },
+    { label: "Upstream keys", value: keyCount, icon: Key },
+    { label: "Access tokens", value: tokenCount, icon: Users },
+  ];
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Overview</h1>
+          <p className="text-sm text-muted-foreground">
+            Your MCP gateway at a glance.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/servers/new">
+            New server <ArrowRight className="ml-1 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {stats.map((s) => (
+          <Card key={s.label}>
+            <CardContent className="flex items-center justify-between p-5">
+              <div>
+                <p className="text-xs text-muted-foreground">{s.label}</p>
+                <p className="mt-1 text-2xl font-semibold tabular-nums">{s.value}</p>
+              </div>
+              <s.icon weight="duotone" className="h-6 w-6 text-muted-foreground" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent servers</CardTitle>
+          <CardDescription>Your most recently updated MCP servers.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {recentServers.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <ul className="divide-y divide-border">
+              {recentServers.map((s) => (
+                <li key={s.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <Link
+                      href={`/servers/${s.id}`}
+                      className="font-medium hover:underline"
+                    >
+                      {s.name}
+                    </Link>
+                    <p className="text-xs text-muted-foreground">
+                      {s._count.tools} tools · {s.openApiDoc?.title} v{s.openApiDoc?.version} · /{s.slug}
+                    </p>
+                  </div>
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link href={`/servers/${s.id}`}>Open</Link>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center">
+      <Stack weight="duotone" className="h-10 w-10 text-muted-foreground" />
+      <p className="text-sm text-muted-foreground">
+        No servers yet. Import an OpenAPI doc to get started.
+      </p>
+      <Button asChild>
+        <Link href="/servers/new">
+          Create your first server <ArrowRight className="ml-1 h-4 w-4" />
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,0 +1,46 @@
+import { requireSession } from "@/server/session";
+import { getDb } from "@/lib/db";
+import { Sidebar } from "@/components/dashboard/sidebar";
+import { OrgSwitcher } from "@/components/dashboard/org-switcher";
+import { UserMenu } from "@/components/dashboard/user-menu";
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await requireSession();
+  const db = getDb();
+
+  const memberships = await db.member.findMany({
+    where: { userId: session.user.id },
+    include: { organization: true },
+    orderBy: { createdAt: "asc" },
+  });
+  const orgs = memberships.map((m) => ({
+    id: m.organization.id,
+    name: m.organization.name,
+    slug: m.organization.slug,
+    role: m.role,
+  }));
+  const activeOrgId = session.session?.activeOrganizationId ?? orgs[0]?.id ?? null;
+
+  return (
+    <div className="flex min-h-dvh">
+      <Sidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-40 flex h-14 items-center justify-between gap-3 border-b bg-background/80 px-4 backdrop-blur md:px-6">
+          <OrgSwitcher initialOrgs={orgs} activeOrgId={activeOrgId} />
+          <UserMenu
+            user={{
+              name: session.user.name,
+              email: session.user.email,
+              image: session.user.image,
+            }}
+          />
+        </header>
+        <main className="flex-1 p-4 md:p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/org/page.tsx
+++ b/app/(dashboard)/org/page.tsx
@@ -1,0 +1,97 @@
+import { getDashboardContext } from "@/server/session";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { InviteMemberForm } from "@/components/dashboard/invite-member-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function OrgPage() {
+  const { db, orgId } = await getDashboardContext();
+  const org = await db.organization.findUnique({ where: { id: orgId } });
+  const members = await db.member.findMany({
+    where: { organizationId: orgId },
+    include: {
+      user: { select: { id: true, name: true, email: true, image: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  const invitations = await db.invitation.findMany({
+    where: { organizationId: orgId, status: "pending" },
+    orderBy: { expiresAt: "desc" },
+  });
+
+  if (!org) return null;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">{org.name}</h1>
+        <p className="text-sm text-muted-foreground">Slug: /{org.slug}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Members</CardTitle>
+          <CardDescription>{members.length} members in this organization.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="divide-y divide-border">
+            {members.map((m) => (
+              <li key={m.id} className="flex items-center gap-3 py-3">
+                <Avatar className="h-8 w-8">
+                  {m.user.image ? <AvatarImage src={m.user.image} /> : null}
+                  <AvatarFallback>
+                    {m.user.name
+                      .split(" ")
+                      .slice(0, 2)
+                      .map((w) => w[0]?.toUpperCase())
+                      .join("")}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{m.user.name}</p>
+                  <p className="truncate text-xs text-muted-foreground">{m.user.email}</p>
+                </div>
+                <Badge variant="outline">{m.role}</Badge>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Invite a member</CardTitle>
+          <CardDescription>Send a signed link to their inbox.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <InviteMemberForm orgId={org.id} />
+        </CardContent>
+      </Card>
+
+      {invitations.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pending invitations</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="divide-y divide-border">
+              {invitations.map((inv) => (
+                <li key={inv.id} className="flex items-center justify-between py-3">
+                  <div>
+                    <p className="text-sm font-medium">{inv.email}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Expires {new Date(inv.expiresAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  {inv.role ? <Badge variant="outline">{inv.role}</Badge> : null}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/servers/[id]/page.tsx
+++ b/app/(dashboard)/servers/[id]/page.tsx
@@ -1,0 +1,179 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Globe, Lock, Eye } from "@phosphor-icons/react/dist/ssr";
+
+import { getDashboardContext } from "@/server/session";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ToolsList } from "@/components/dashboard/tools-list";
+import { AccessTokensPanel } from "@/components/dashboard/access-tokens-panel";
+import { ApiKeysPanel } from "@/components/dashboard/api-keys-panel";
+import { ServerSettings } from "@/components/dashboard/server-settings";
+import { McpEndpointBadge } from "@/components/dashboard/mcp-endpoint-badge";
+
+export const dynamic = "force-dynamic";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ServerDetailPage({ params }: Props) {
+  const { id } = await params;
+  const { db, orgId } = await getDashboardContext();
+
+  const server = await db.mcpServer.findFirst({
+    where: { id, organizationId: orgId },
+    include: {
+      openApiDoc: { select: { title: true, version: true } },
+      tools: { orderBy: { name: "asc" } },
+      apiKeys: {
+        select: {
+          id: true,
+          name: true,
+          type: true,
+          paramName: true,
+          schemeKey: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "desc" },
+      },
+      accessTokens: {
+        select: {
+          id: true,
+          name: true,
+          prefix: true,
+          lastUsedAt: true,
+          expiresAt: true,
+          revokedAt: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "desc" },
+      },
+      _count: { select: { logs: true } },
+    },
+  });
+  if (!server) notFound();
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <div>
+        <Link
+          href="/servers"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3 w-3" /> Back to servers
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold">{server.name}</h1>
+            <VisibilityBadge visibility={server.visibility} />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            /{server.slug} · {server.openApiDoc?.title} v{server.openApiDoc?.version} ·{" "}
+            {server.tools.length} tools
+          </p>
+          {server.description ? (
+            <p className="mt-3 max-w-3xl text-sm">{server.description}</p>
+          ) : null}
+        </div>
+        <McpEndpointBadge slug={server.slug} />
+      </div>
+
+      <Tabs defaultValue="tools">
+        <TabsList>
+          <TabsTrigger value="tools">Tools ({server.tools.length})</TabsTrigger>
+          <TabsTrigger value="tokens">
+            Access tokens ({server.accessTokens.length})
+          </TabsTrigger>
+          <TabsTrigger value="keys">Upstream keys ({server.apiKeys.length})</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="tools">
+          <Card>
+            <CardHeader>
+              <CardTitle>Tools</CardTitle>
+              <CardDescription>
+                Disabled tools are hidden from <code>tools/list</code>.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ToolsList
+                serverId={server.id}
+                tools={server.tools.map((t) => ({
+                  id: t.id,
+                  name: t.name,
+                  method: t.method,
+                  path: t.path,
+                  description: t.description,
+                  summary: t.summary,
+                  enabled: t.enabled,
+                }))}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="tokens">
+          <AccessTokensPanel
+            serverId={server.id}
+            tokens={server.accessTokens.map((t) => ({
+              ...t,
+              expiresAt: t.expiresAt ? t.expiresAt.toISOString() : null,
+              revokedAt: t.revokedAt ? t.revokedAt.toISOString() : null,
+              createdAt: t.createdAt.toISOString(),
+              lastUsedAt: t.lastUsedAt ? t.lastUsedAt.toISOString() : null,
+            }))}
+          />
+        </TabsContent>
+
+        <TabsContent value="keys">
+          <ApiKeysPanel
+            serverId={server.id}
+            keys={server.apiKeys.map((k) => ({
+              ...k,
+              createdAt: k.createdAt.toISOString(),
+            }))}
+          />
+        </TabsContent>
+
+        <TabsContent value="settings">
+          <ServerSettings
+            serverId={server.id}
+            initial={{
+              name: server.name,
+              slug: server.slug,
+              description: server.description,
+              baseUrl: server.baseUrl,
+              visibility: server.visibility,
+            }}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function VisibilityBadge({ visibility }: { visibility: string }) {
+  if (visibility === "PUBLIC")
+    return (
+      <Badge variant="success" className="gap-1">
+        <Globe className="h-3 w-3" /> Public
+      </Badge>
+    );
+  if (visibility === "UNLISTED")
+    return (
+      <Badge variant="secondary" className="gap-1">
+        <Eye className="h-3 w-3" /> Unlisted
+      </Badge>
+    );
+  return (
+    <Badge variant="outline" className="gap-1">
+      <Lock className="h-3 w-3" /> Private
+    </Badge>
+  );
+}

--- a/app/(dashboard)/servers/new/page.tsx
+++ b/app/(dashboard)/servers/new/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { NewServerWizard } from "@/components/dashboard/new-server-wizard";
+
+export const metadata: Metadata = { title: "New server" };
+
+export default function NewServerPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Create MCP server</h1>
+        <p className="text-sm text-muted-foreground">
+          Import an OpenAPI document and pick which operations become tools.
+        </p>
+      </div>
+      <NewServerWizard />
+    </div>
+  );
+}

--- a/app/(dashboard)/servers/page.tsx
+++ b/app/(dashboard)/servers/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { ArrowRight, Stack, Plus, Globe, Lock, Eye } from "@phosphor-icons/react/dist/ssr";
+
+import { getDashboardContext } from "@/server/session";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardTitle, CardDescription } from "@/components/ui/card";
+
+export const dynamic = "force-dynamic";
+
+export default async function ServersPage() {
+  const { db, orgId } = await getDashboardContext();
+  const servers = await db.mcpServer.findMany({
+    where: { organizationId: orgId },
+    include: {
+      _count: { select: { tools: true } },
+      openApiDoc: { select: { title: true, version: true } },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Servers</h1>
+          <p className="text-sm text-muted-foreground">
+            MCP servers compiled from OpenAPI documents in this organization.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/servers/new">
+            <Plus className="h-4 w-4" /> New server
+          </Link>
+        </Button>
+      </div>
+
+      {servers.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+            <Stack weight="duotone" className="h-10 w-10 text-muted-foreground" />
+            <div>
+              <CardTitle className="text-base">No servers yet</CardTitle>
+              <CardDescription className="mt-1">
+                Turn an OpenAPI spec into a hosted MCP server in under a minute.
+              </CardDescription>
+            </div>
+            <Button asChild>
+              <Link href="/servers/new">
+                Create server <ArrowRight className="ml-1 h-4 w-4" />
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {servers.map((s) => (
+            <Link
+              key={s.id}
+              href={`/servers/${s.id}`}
+              className="group rounded-xl border bg-card p-5 transition-colors hover:border-primary/50"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h3 className="truncate font-medium group-hover:text-primary">
+                      {s.name}
+                    </h3>
+                    <VisibilityBadge visibility={s.visibility} />
+                  </div>
+                  <p className="mt-1 truncate text-xs text-muted-foreground">
+                    /{s.slug} · {s.openApiDoc?.title} v{s.openApiDoc?.version}
+                  </p>
+                </div>
+                <Badge variant="outline" className="shrink-0">
+                  {s._count.tools} tools
+                </Badge>
+              </div>
+              {s.description ? (
+                <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
+                  {s.description}
+                </p>
+              ) : null}
+              <p className="mt-3 truncate font-mono text-xs text-muted-foreground">
+                {s.baseUrl}
+              </p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VisibilityBadge({ visibility }: { visibility: string }) {
+  if (visibility === "PUBLIC") {
+    return (
+      <Badge variant="success" className="gap-1">
+        <Globe className="h-3 w-3" /> Public
+      </Badge>
+    );
+  }
+  if (visibility === "UNLISTED") {
+    return (
+      <Badge variant="secondary" className="gap-1">
+        <Eye className="h-3 w-3" /> Unlisted
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="gap-1">
+      <Lock className="h-3 w-3" /> Private
+    </Badge>
+  );
+}

--- a/src/components/dashboard/access-tokens-panel.tsx
+++ b/src/components/dashboard/access-tokens-panel.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Copy, Plus, Trash, CheckCircle } from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+
+interface TokenRow {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+}
+
+export function AccessTokensPanel({
+  serverId,
+  tokens: initial,
+}: {
+  serverId: string;
+  tokens: TokenRow[];
+}) {
+  const [tokens, setTokens] = useState(initial);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [pending, start] = useTransition();
+  const [revealed, setRevealed] = useState<{ token: string; name: string } | null>(null);
+
+  const create = () => {
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}/access-tokens`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name }),
+        credentials: "include",
+      });
+      if (!res.ok) {
+        toast.error("Could not create token.");
+        return;
+      }
+      const { token, raw } = (await res.json()) as {
+        token: TokenRow & { expiresAt: string | null };
+        raw: string;
+      };
+      setTokens((t) => [
+        {
+          ...token,
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+        ...t,
+      ]);
+      setRevealed({ token: raw, name });
+      setCreateOpen(false);
+      setName("");
+    });
+  };
+
+  const revoke = (id: string) => {
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}/access-tokens/${id}/revoke`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        toast.error("Could not revoke token.");
+        return;
+      }
+      setTokens((t) =>
+        t.map((x) => (x.id === id ? { ...x, revokedAt: new Date().toISOString() } : x))
+      );
+      toast.success("Token revoked.");
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between space-y-0">
+        <div>
+          <CardTitle>Access tokens</CardTitle>
+          <CardDescription>
+            Bearer tokens MCP clients present when calling this server.
+          </CardDescription>
+        </div>
+        <Button onClick={() => setCreateOpen(true)} size="sm">
+          <Plus className="h-4 w-4" /> New token
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {tokens.length === 0 ? (
+          <p className="py-10 text-center text-sm text-muted-foreground">
+            No tokens yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {tokens.map((t) => (
+              <li key={t.id} className="flex items-center justify-between gap-3 py-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{t.name}</span>
+                    {t.revokedAt ? (
+                      <Badge variant="destructive">Revoked</Badge>
+                    ) : t.expiresAt && new Date(t.expiresAt) < new Date() ? (
+                      <Badge variant="warning">Expired</Badge>
+                    ) : (
+                      <Badge variant="success">Active</Badge>
+                    )}
+                  </div>
+                  <p className="mt-1 font-mono text-xs text-muted-foreground">
+                    {t.prefix}…
+                    {t.lastUsedAt ? ` · last used ${new Date(t.lastUsedAt).toLocaleString()}` : ""}
+                  </p>
+                </div>
+                {!t.revokedAt && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => revoke(t.id)}
+                    disabled={pending}
+                    aria-label="Revoke"
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New access token</DialogTitle>
+            <DialogDescription>
+              You&apos;ll only see the raw value once.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="token-name">Name</Label>
+            <Input
+              id="token-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Claude Desktop on laptop"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setCreateOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={create} disabled={!name || pending}>
+              Create token
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!revealed}
+        onOpenChange={(o) => !o && setRevealed(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Token created</DialogTitle>
+            <DialogDescription>
+              Copy this now — it will never be shown again.
+            </DialogDescription>
+          </DialogHeader>
+          {revealed ? <RevealBox value={revealed.token} /> : null}
+          <DialogFooter>
+            <Button onClick={() => setRevealed(null)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+function RevealBox({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-muted p-3 font-mono text-xs">
+      <span className="min-w-0 flex-1 break-all">{value}</span>
+      <Button size="icon" variant="ghost" onClick={copy} aria-label="Copy token">
+        {copied ? (
+          <CheckCircle className="h-4 w-4 text-emerald-500" />
+        ) : (
+          <Copy className="h-4 w-4" />
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/dashboard/api-keys-panel.tsx
+++ b/src/components/dashboard/api-keys-panel.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Plus, Trash } from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+
+type AuthType = "NONE" | "BEARER" | "HEADER" | "QUERY" | "BASIC";
+
+interface KeyRow {
+  id: string;
+  name: string;
+  type: AuthType;
+  paramName: string | null;
+  schemeKey: string | null;
+  createdAt: string;
+}
+
+export function ApiKeysPanel({
+  serverId,
+  keys: initial,
+}: {
+  serverId: string;
+  keys: KeyRow[];
+}) {
+  const [keys, setKeys] = useState(initial);
+  const [open, setOpen] = useState(false);
+  const [pending, start] = useTransition();
+
+  const [form, setForm] = useState<{
+    name: string;
+    type: AuthType;
+    paramName: string;
+    schemeKey: string;
+    secret: string;
+  }>({
+    name: "",
+    type: "BEARER",
+    paramName: "",
+    schemeKey: "",
+    secret: "",
+  });
+
+  const create = () => {
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}/api-keys`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: form.name,
+          type: form.type,
+          paramName: form.paramName || null,
+          schemeKey: form.schemeKey || null,
+          secret: form.secret,
+        }),
+        credentials: "include",
+      });
+      if (!res.ok) {
+        toast.error("Could not save key.");
+        return;
+      }
+      const { key } = (await res.json()) as { key: KeyRow };
+      setKeys((k) => [key, ...k]);
+      setOpen(false);
+      setForm({ name: "", type: "BEARER", paramName: "", schemeKey: "", secret: "" });
+      toast.success("Key stored (encrypted).");
+    });
+  };
+
+  const remove = (id: string) => {
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}/api-keys/${id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        toast.error("Could not delete key.");
+        return;
+      }
+      setKeys((k) => k.filter((x) => x.id !== id));
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between space-y-0">
+        <div>
+          <CardTitle>Upstream credentials</CardTitle>
+          <CardDescription>
+            Encrypted with AES-256-GCM. Injected into outbound requests at execution time.
+          </CardDescription>
+        </div>
+        <Button onClick={() => setOpen(true)} size="sm">
+          <Plus className="h-4 w-4" /> Add key
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {keys.length === 0 ? (
+          <p className="py-10 text-center text-sm text-muted-foreground">
+            No upstream credentials.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {keys.map((k) => (
+              <li key={k.id} className="flex items-center justify-between gap-3 py-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{k.name}</span>
+                    <Badge variant="outline">{k.type.toLowerCase()}</Badge>
+                    {k.schemeKey ? (
+                      <Badge variant="secondary">scheme: {k.schemeKey}</Badge>
+                    ) : null}
+                  </div>
+                  {k.paramName ? (
+                    <p className="mt-1 font-mono text-xs text-muted-foreground">
+                      {k.paramName}
+                    </p>
+                  ) : null}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => remove(k.id)}
+                  disabled={pending}
+                  aria-label="Delete key"
+                >
+                  <Trash className="h-4 w-4" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add upstream credential</DialogTitle>
+            <DialogDescription>
+              Bind this to a security scheme in your OpenAPI doc for automatic injection.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="k-name">Label</Label>
+              <Input
+                id="k-name"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="Production API key"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="k-type">Type</Label>
+              <select
+                id="k-type"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm"
+                value={form.type}
+                onChange={(e) => setForm({ ...form, type: e.target.value as AuthType })}
+              >
+                <option value="BEARER">Bearer token</option>
+                <option value="HEADER">Header</option>
+                <option value="QUERY">Query parameter</option>
+                <option value="BASIC">Basic auth (user:pass)</option>
+              </select>
+            </div>
+            {(form.type === "HEADER" || form.type === "QUERY") && (
+              <div className="space-y-2">
+                <Label htmlFor="k-param">Parameter name</Label>
+                <Input
+                  id="k-param"
+                  value={form.paramName}
+                  onChange={(e) => setForm({ ...form, paramName: e.target.value })}
+                  placeholder="X-API-Key"
+                />
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="k-scheme">OpenAPI scheme (optional)</Label>
+              <Input
+                id="k-scheme"
+                value={form.schemeKey}
+                onChange={(e) => setForm({ ...form, schemeKey: e.target.value })}
+                placeholder="apiKeyAuth"
+              />
+              <p className="text-xs text-muted-foreground">
+                Matches <code>components.securitySchemes.&lt;name&gt;</code>.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="k-secret">Secret</Label>
+              <Input
+                id="k-secret"
+                type="password"
+                value={form.secret}
+                onChange={(e) => setForm({ ...form, secret: e.target.value })}
+                autoComplete="off"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={create}
+              disabled={pending || !form.name || !form.secret}
+            >
+              Save (encrypted)
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/components/dashboard/invite-member-form.tsx
+++ b/src/components/dashboard/invite-member-form.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PaperPlaneTilt } from "@phosphor-icons/react/dist/ssr";
+
+import { organization } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function InviteMemberForm({ orgId }: { orgId: string }) {
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<"owner" | "admin" | "member">("member");
+  const [pending, start] = useTransition();
+  const router = useRouter();
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    start(async () => {
+      const { error } = await organization.inviteMember({
+        email,
+        role,
+        organizationId: orgId,
+      });
+      if (error) {
+        toast.error(error.message ?? "Could not send invitation.");
+        return;
+      }
+      toast.success(`Invitation sent to ${email}.`);
+      setEmail("");
+      router.refresh();
+    });
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+      <div className="flex-1 space-y-2">
+        <Label htmlFor="invite-email">Email</Label>
+        <Input
+          id="invite-email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="teammate@example.com"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="invite-role">Role</Label>
+        <select
+          id="invite-role"
+          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-sm sm:w-40"
+          value={role}
+          onChange={(e) => setRole(e.target.value as typeof role)}
+        >
+          <option value="member">Member</option>
+          <option value="admin">Admin</option>
+          <option value="owner">Owner</option>
+        </select>
+      </div>
+      <Button type="submit" disabled={pending}>
+        <PaperPlaneTilt className="h-4 w-4" /> Send invite
+      </Button>
+    </form>
+  );
+}

--- a/src/components/dashboard/mcp-endpoint-badge.tsx
+++ b/src/components/dashboard/mcp-endpoint-badge.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, CheckCircle } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+export function McpEndpointBadge({ slug }: { slug: string }) {
+  const [copied, setCopied] = useState(false);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const url = `${origin}/mcp/${slug}`;
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    toast.success("Endpoint copied.");
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border bg-muted/40 p-2 font-mono text-xs">
+      <span className="max-w-[320px] truncate px-2">{url}</span>
+      <Button size="icon" variant="ghost" onClick={copy} aria-label="Copy endpoint">
+        {copied ? (
+          <CheckCircle className="h-4 w-4 text-emerald-500" />
+        ) : (
+          <Copy className="h-4 w-4" />
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/dashboard/new-server-wizard.tsx
+++ b/src/components/dashboard/new-server-wizard.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  ArrowRight,
+  CheckCircle,
+  CloudArrowUp,
+  FileText,
+  LinkSimple,
+} from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { slugify } from "@/lib/utils";
+
+type IngestResult = {
+  id: string;
+  title: string;
+  version: string;
+  toolCount: number;
+  baseUrl: string | null;
+};
+
+export function NewServerWizard() {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [pending, start] = useTransition();
+  const [doc, setDoc] = useState<IngestResult | null>(null);
+
+  // Step 1 inputs
+  const [url, setUrl] = useState("");
+  const [text, setText] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+
+  // Step 2 inputs
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [visibility, setVisibility] = useState<"PRIVATE" | "UNLISTED" | "PUBLIC">(
+    "PRIVATE"
+  );
+
+  const router = useRouter();
+
+  const ingestUrl = () => {
+    if (!url) return;
+    start(async () => {
+      const res = await fetch("/api/openapi/from-url", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url }),
+        credentials: "include",
+      });
+      await handleIngest(res);
+    });
+  };
+
+  const ingestText = () => {
+    if (!text) return;
+    start(async () => {
+      const res = await fetch("/api/openapi/from-text", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: text, source: "PASTE" }),
+        credentials: "include",
+      });
+      await handleIngest(res);
+    });
+  };
+
+  const ingestFile = () => {
+    if (!file) return;
+    start(async () => {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/openapi/from-file", {
+        method: "POST",
+        body: fd,
+        credentials: "include",
+      });
+      await handleIngest(res);
+    });
+  };
+
+  const handleIngest = async (res: Response) => {
+    if (!res.ok) {
+      const data = (await res.json().catch(() => ({}))) as { message?: string };
+      toast.error(data?.message ?? "Failed to import OpenAPI document.");
+      return;
+    }
+    const { doc: d } = (await res.json()) as { doc: IngestResult };
+    setDoc(d);
+    setName(d.title);
+    setSlug(slugify(d.title));
+    setBaseUrl(d.baseUrl ?? "");
+    setStep(2);
+  };
+
+  const create = () => {
+    if (!doc) return;
+    start(async () => {
+      const res = await fetch("/api/servers", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name,
+          slug,
+          description: description || null,
+          baseUrl: baseUrl || null,
+          visibility,
+          openApiDocId: doc.id,
+        }),
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { message?: string };
+        toast.error(data?.message ?? "Could not create server.");
+        return;
+      }
+      const { server } = (await res.json()) as { server: { id: string } };
+      toast.success("Server created.");
+      router.push(`/servers/${server.id}`);
+      router.refresh();
+    });
+  };
+
+  if (step === 2 && doc) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Configure server</CardTitle>
+          <CardDescription>
+            {doc.toolCount} tools discovered in {doc.title} v{doc.version}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="slug">Slug</Label>
+            <Input
+              id="slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Your MCP endpoint will be{" "}
+              <span className="font-mono">
+                {typeof window !== "undefined" ? window.location.origin : ""}
+                /mcp/{slug || "…"}
+              </span>
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Shown to agents as the server’s purpose."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="baseUrl">Base URL</Label>
+            <Input
+              id="baseUrl"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.example.com"
+            />
+            <p className="text-xs text-muted-foreground">
+              Defaults to the first <code>servers[]</code> entry in your spec.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label>Visibility</Label>
+            <div className="grid grid-cols-3 gap-2">
+              {(["PRIVATE", "UNLISTED", "PUBLIC"] as const).map((v) => (
+                <button
+                  type="button"
+                  key={v}
+                  onClick={() => setVisibility(v)}
+                  className={
+                    "rounded-md border px-3 py-2 text-sm transition-colors " +
+                    (visibility === v
+                      ? "border-primary bg-primary/10"
+                      : "hover:bg-accent")
+                  }
+                >
+                  {v.toLowerCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-between pt-2">
+            <Button variant="ghost" onClick={() => setStep(1)}>
+              Back
+            </Button>
+            <Button onClick={create} disabled={pending || !name || !slug}>
+              {pending ? "Creating…" : "Create server"}
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Import OpenAPI</CardTitle>
+        <CardDescription>
+          Supply a URL, paste JSON, or upload a file. JSON only for now — YAML coming soon.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="url">
+          <TabsList>
+            <TabsTrigger value="url">
+              <LinkSimple className="h-4 w-4" /> URL
+            </TabsTrigger>
+            <TabsTrigger value="paste">
+              <FileText className="h-4 w-4" /> Paste
+            </TabsTrigger>
+            <TabsTrigger value="upload">
+              <CloudArrowUp className="h-4 w-4" /> Upload
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="url" className="space-y-3 pt-4">
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://petstore3.swagger.io/api/v3/openapi.json"
+            />
+            <Button onClick={ingestUrl} disabled={pending || !url}>
+              {pending ? "Fetching…" : "Import"}
+            </Button>
+          </TabsContent>
+
+          <TabsContent value="paste" className="space-y-3 pt-4">
+            <Textarea
+              rows={10}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder='{"openapi":"3.1.0",...}'
+              className="font-mono text-xs"
+            />
+            <Button onClick={ingestText} disabled={pending || !text}>
+              {pending ? "Parsing…" : "Import"}
+            </Button>
+          </TabsContent>
+
+          <TabsContent value="upload" className="space-y-3 pt-4">
+            <Input
+              type="file"
+              accept="application/json,.json"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+            {file ? (
+              <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <CheckCircle className="h-4 w-4 text-emerald-500" />
+                {file.name} · {(file.size / 1024).toFixed(1)} KB
+              </p>
+            ) : null}
+            <Button onClick={ingestFile} disabled={pending || !file}>
+              {pending ? "Uploading…" : "Import"}
+            </Button>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/onboarding-form.tsx
+++ b/src/components/dashboard/onboarding-form.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ArrowRight } from "@phosphor-icons/react/dist/ssr";
+
+import { organization } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { slugify } from "@/lib/utils";
+
+export function OnboardingForm() {
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [pending, start] = useTransition();
+  const router = useRouter();
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    start(async () => {
+      const finalSlug = slug.trim() || slugify(name);
+      const { data, error } = await organization.create({ name, slug: finalSlug });
+      if (error) {
+        toast.error(error.message ?? "Could not create organization.");
+        return;
+      }
+      if (data?.id) await organization.setActive({ organizationId: data.id });
+      toast.success("Workspace ready.");
+      router.push("/dashboard");
+      router.refresh();
+    });
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="on-name">Workspace name</Label>
+        <Input
+          id="on-name"
+          required
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (!slug) setSlug(slugify(e.target.value));
+          }}
+          placeholder="Acme Labs"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="on-slug">Slug</Label>
+        <Input
+          id="on-slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="acme-labs"
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={pending || !name}>
+        {pending ? "Creating…" : "Create workspace"}
+        <ArrowRight className="ml-1 h-4 w-4" />
+      </Button>
+    </form>
+  );
+}

--- a/src/components/dashboard/org-switcher.tsx
+++ b/src/components/dashboard/org-switcher.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { CaretUpDown, Check, Plus } from "@phosphor-icons/react/dist/ssr";
+
+import { organization } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { slugify } from "@/lib/utils";
+
+interface OrgRow {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+}
+
+export function OrgSwitcher({
+  initialOrgs,
+  activeOrgId,
+}: {
+  initialOrgs: OrgRow[];
+  activeOrgId: string | null;
+}) {
+  const [orgs, setOrgs] = useState(initialOrgs);
+  const [active, setActive] = useState(activeOrgId);
+  const [pending, startTransition] = useTransition();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newSlug, setNewSlug] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    setOrgs(initialOrgs);
+    setActive(activeOrgId);
+  }, [initialOrgs, activeOrgId]);
+
+  const current = orgs.find((o) => o.id === active) ?? orgs[0];
+
+  const switchTo = (id: string) => {
+    startTransition(async () => {
+      await organization.setActive({ organizationId: id });
+      setActive(id);
+      router.refresh();
+    });
+  };
+
+  const onCreate = () => {
+    startTransition(async () => {
+      const slug = newSlug.trim() || slugify(newName);
+      const { data, error } = await organization.create({ name: newName, slug });
+      if (error) {
+        toast.error(error.message ?? "Could not create organization.");
+        return;
+      }
+      if (data?.id) {
+        await organization.setActive({ organizationId: data.id });
+      }
+      toast.success("Organization created.");
+      setCreateOpen(false);
+      setNewName("");
+      setNewSlug("");
+      router.refresh();
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-2" disabled={pending}>
+            <span className="truncate max-w-[160px]">
+              {current?.name ?? "No organization"}
+            </span>
+            <CaretUpDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-60">
+          <DropdownMenuLabel>Your organizations</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {orgs.map((o) => (
+            <DropdownMenuItem key={o.id} onSelect={() => switchTo(o.id)}>
+              <span className="flex-1 truncate">{o.name}</span>
+              {o.id === active && <Check className="h-4 w-4" />}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={(e) => { e.preventDefault(); setCreateOpen(true); }}>
+            <Plus className="h-4 w-4" /> Create organization
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create organization</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="org-name">Name</Label>
+              <Input
+                id="org-name"
+                value={newName}
+                onChange={(e) => {
+                  setNewName(e.target.value);
+                  if (!newSlug) setNewSlug(slugify(e.target.value));
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="org-slug">Slug</Label>
+              <Input
+                id="org-slug"
+                value={newSlug}
+                onChange={(e) => setNewSlug(e.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button onClick={onCreate} disabled={pending || !newName}>
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/dashboard/server-settings.tsx
+++ b/src/components/dashboard/server-settings.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Trash } from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Visibility = "PRIVATE" | "UNLISTED" | "PUBLIC";
+
+export function ServerSettings({
+  serverId,
+  initial,
+}: {
+  serverId: string;
+  initial: {
+    name: string;
+    slug: string;
+    description: string | null;
+    baseUrl: string;
+    visibility: Visibility;
+  };
+}) {
+  const [form, setForm] = useState(initial);
+  const [pending, start] = useTransition();
+  const router = useRouter();
+
+  const save = () => {
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: form.name,
+          slug: form.slug,
+          description: form.description,
+          baseUrl: form.baseUrl,
+          visibility: form.visibility,
+        }),
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { message?: string };
+        toast.error(data?.message ?? "Could not save.");
+        return;
+      }
+      toast.success("Settings saved.");
+      router.refresh();
+    });
+  };
+
+  const destroy = () => {
+    if (!confirm("Delete this server? This cannot be undone.")) return;
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        toast.error("Could not delete.");
+        return;
+      }
+      toast.success("Server deleted.");
+      router.push("/servers");
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>General</CardTitle>
+          <CardDescription>Control how your server is identified.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="s-name">Name</Label>
+            <Input
+              id="s-name"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="s-slug">Slug</Label>
+            <Input
+              id="s-slug"
+              value={form.slug}
+              onChange={(e) => setForm({ ...form, slug: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="s-desc">Description</Label>
+            <Textarea
+              id="s-desc"
+              value={form.description ?? ""}
+              onChange={(e) =>
+                setForm({ ...form, description: e.target.value || null })
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="s-base">Base URL</Label>
+            <Input
+              id="s-base"
+              value={form.baseUrl}
+              onChange={(e) => setForm({ ...form, baseUrl: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Visibility</Label>
+            <div className="grid grid-cols-3 gap-2">
+              {(["PRIVATE", "UNLISTED", "PUBLIC"] as const).map((v) => (
+                <button
+                  type="button"
+                  key={v}
+                  onClick={() => setForm({ ...form, visibility: v })}
+                  className={
+                    "rounded-md border px-3 py-2 text-sm transition-colors " +
+                    (form.visibility === v
+                      ? "border-primary bg-primary/10"
+                      : "hover:bg-accent")
+                  }
+                >
+                  {v.toLowerCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={save} disabled={pending}>
+              {pending ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-destructive/40">
+        <CardHeader>
+          <CardTitle className="text-destructive">Danger zone</CardTitle>
+          <CardDescription>
+            Deletes this server, its tools, credentials, and access tokens.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            This cannot be undone.
+          </p>
+          <Button variant="destructive" onClick={destroy} disabled={pending}>
+            <Trash className="h-4 w-4" /> Delete server
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  House,
+  Stack,
+  Users,
+  GearSix,
+  Plug,
+  Plus,
+} from "@phosphor-icons/react/dist/ssr";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+const nav = [
+  { href: "/dashboard", label: "Overview", icon: House },
+  { href: "/servers", label: "Servers", icon: Stack },
+  { href: "/org", label: "Organization", icon: Users },
+  { href: "/account", label: "Account", icon: GearSix },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="hidden w-60 shrink-0 border-r bg-card/30 md:flex md:flex-col">
+      <div className="flex h-14 items-center gap-2 border-b px-4 font-semibold">
+        <Plug weight="duotone" className="h-5 w-5 text-primary" />
+        oh-my-mcp
+      </div>
+      <div className="flex-1 space-y-1 p-3">
+        <Button asChild size="sm" className="mb-3 w-full justify-start gap-2">
+          <Link href="/servers/new">
+            <Plus className="h-4 w-4" /> New server
+          </Link>
+        </Button>
+        {nav.map((item) => {
+          const active =
+            item.href === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname?.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
+                active && "bg-accent text-accent-foreground"
+              )}
+            >
+              <item.icon weight="duotone" className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+      <div className="border-t p-3 text-xs text-muted-foreground">
+        <p>
+          Docs:{" "}
+          <a
+            href="https://modelcontextprotocol.io"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            MCP spec
+          </a>
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/dashboard/tools-list.tsx
+++ b/src/components/dashboard/tools-list.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+
+interface Tool {
+  id: string;
+  name: string;
+  method: string;
+  path: string;
+  summary: string | null;
+  description: string | null;
+  enabled: boolean;
+}
+
+export function ToolsList({
+  serverId,
+  tools: initialTools,
+}: {
+  serverId: string;
+  tools: Tool[];
+}) {
+  const [tools, setTools] = useState(initialTools);
+  const [, start] = useTransition();
+
+  const toggle = (toolId: string, enabled: boolean) => {
+    const previous = tools;
+    setTools((t) => t.map((x) => (x.id === toolId ? { ...x, enabled } : x)));
+    start(async () => {
+      const res = await fetch(`/api/servers/${serverId}/tools/${toolId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled }),
+        credentials: "include",
+      });
+      if (!res.ok) {
+        setTools(previous);
+        toast.error("Could not update tool.");
+      }
+    });
+  };
+
+  if (tools.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        No tools — re-import the OpenAPI document.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border">
+      {tools.map((t) => (
+        <li key={t.id} className="flex items-center justify-between gap-4 py-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="font-mono text-[10px]">
+                {t.method}
+              </Badge>
+              <span className="truncate font-mono text-sm">{t.name}</span>
+            </div>
+            <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+              {t.path}
+            </p>
+            {(t.summary || t.description) && (
+              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                {t.summary ?? t.description}
+              </p>
+            )}
+          </div>
+          <Switch
+            checked={t.enabled}
+            onCheckedChange={(v) => toggle(t.id, v)}
+            aria-label={`Enable ${t.name}`}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/dashboard/user-menu.tsx
+++ b/src/components/dashboard/user-menu.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import Link from "next/link";
+import { SignOut, UserCircle, Moon, Sun } from "@phosphor-icons/react/dist/ssr";
+import { useTheme } from "next-themes";
+
+import { signOut } from "@/lib/auth-client";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+
+interface User {
+  name: string;
+  email: string;
+  image?: string | null;
+}
+
+export function UserMenu({ user }: { user: User }) {
+  const [pending, start] = useTransition();
+  const router = useRouter();
+  const { theme, setTheme } = useTheme();
+
+  const initials = user.name
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase())
+    .join("");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" disabled={pending}>
+          <Avatar className="h-7 w-7">
+            {user.image ? <AvatarImage src={user.image} alt={user.name} /> : null}
+            <AvatarFallback>{initials || <UserCircle />}</AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>
+          <div className="truncate text-sm font-medium">{user.name}</div>
+          <div className="truncate text-xs text-muted-foreground">{user.email}</div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/account">Account settings</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            setTheme(theme === "dark" ? "light" : "dark");
+          }}
+        >
+          {theme === "dark" ? (
+            <>
+              <Sun className="h-4 w-4" /> Light mode
+            </>
+          ) : (
+            <>
+              <Moon className="h-4 w-4" /> Dark mode
+            </>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault();
+            start(async () => {
+              await signOut();
+              router.push("/");
+              router.refresh();
+            });
+          }}
+        >
+          <SignOut className="h-4 w-4" /> Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
Closes #15

Full auth-gated dashboard. Users can:

- Pick an organization / create one / invite teammates
- Import an OpenAPI doc via URL, paste, or file upload
- Toggle tools on/off, mint Bearer access tokens, store encrypted upstream credentials
- Edit or delete a server

All reads happen in RSC via Prisma; all mutations go through `/api/*` Hono routers.