### PR TITLE
chore(security): broaden .env ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,9 @@ next-env.d.ts
 .dev.vars.*
 cloudflare-env.d.ts
 
-# env
-.env
-.env.local
-.env.*.local
+# env — ignore every variant, then re-allow the committed template
+.env*
+!.env.example
 
 # prisma
 prisma/generated/


### PR DESCRIPTION
Closes #21

Replaces three narrow ignore rules with a single broad pattern plus an allow-list for the committed example file.