### PR TITLE
fix(db): add createdAt to Invitation model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,6 +127,7 @@ model Invitation {
   role           String?
   status         String       @default("pending")
   expiresAt      DateTime
+  createdAt      DateTime     @default(now())
   inviterId      String
   inviter        User         @relation(fields: [inviterId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
Closes #25

Adds `createdAt DateTime @default(now())` to the `Invitation` model so the better-auth organization plugin can read/write it.

### Migration required

Run locally after merging:

```bash
pnpm db:migrate -- --name add-invitation-createdat
```