### PR TITLE
fix(api): enforce server/org ownership on writes + member listing

### DIFF
--- a/src/server/routers/access-tokens.ts
+++ b/src/server/routers/access-tokens.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { zValidator } from "@hono/zod-validator";
 
 import type { Env } from "../context";
@@ -64,10 +65,13 @@ export const accessTokensRouter = new Hono<Env>()
     const serverId = c.req.param("serverId")!;
     const tokenId = c.req.param("tokenId");
     await loadServer(c, serverId);
-    await c.var.db.mcpAccessToken.update({
-      where: { id: tokenId },
+    // Tie the revocation predicate to the verified server so a known
+    // token ID from another server/org cannot be revoked here.
+    const { count } = await c.var.db.mcpAccessToken.updateMany({
+      where: { id: tokenId, serverId },
       data: { revokedAt: new Date() },
     });
+    if (count === 0) throw new HTTPException(404, { message: "Token not found." });
     return c.json({ ok: true });
   });
 

--- a/src/server/routers/api-keys.ts
+++ b/src/server/routers/api-keys.ts
@@ -69,7 +69,12 @@ export const apiKeysRouter = new Hono<Env>()
     const serverId = c.req.param("serverId")!;
     const keyId = c.req.param("keyId");
     await loadServer(c, serverId);
-    await c.var.db.mcpApiKey.delete({ where: { id: keyId } });
+    // Compound predicate prevents cross-tenant deletion when a key ID
+    // from another server/org is known.
+    const { count } = await c.var.db.mcpApiKey.deleteMany({
+      where: { id: keyId, serverId },
+    });
+    if (count === 0) throw new HTTPException(404, { message: "Key not found." });
     return c.json({ ok: true });
   });
 

--- a/src/server/routers/orgs.ts
+++ b/src/server/routers/orgs.ts
@@ -48,6 +48,15 @@ export const orgsRouter = new Hono<Env>()
 
   .get("/:orgId/members", async (c) => {
     const orgId = c.req.param("orgId");
+    const userId = c.var.session!.user.id;
+    // Anyone signed in can hit this route; only return data if the caller
+    // is a member of the target org. Without this guard, any user who
+    // learns an org ID could enumerate member identities and emails.
+    const membership = await c.var.db.member.findFirst({
+      where: { organizationId: orgId, userId },
+      select: { id: true },
+    });
+    if (!membership) throw new HTTPException(403, { message: "Forbidden." });
     const members = await c.var.db.member.findMany({
       where: { organizationId: orgId },
       include: { user: { select: { id: true, name: true, email: true, image: true } } },

--- a/src/server/routers/tools.ts
+++ b/src/server/routers/tools.ts
@@ -38,12 +38,18 @@ export const toolsRouter = new Hono<Env>()
       const toolId = c.req.param("toolId");
       await loadServer(c, serverId);
       const body = c.req.valid("json");
-      const tool = await c.var.db.mcpTool.update({
-        where: { id: toolId },
+      // Scope the write to the verified server to prevent cross-tenant
+      // modification when a tool ID from another server/org is known.
+      const { count } = await c.var.db.mcpTool.updateMany({
+        where: { id: toolId, serverId },
         data: {
           ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
           ...(body.description !== undefined ? { description: body.description } : {}),
         },
+      });
+      if (count === 0) throw new HTTPException(404, { message: "Tool not found." });
+      const tool = await c.var.db.mcpTool.findUniqueOrThrow({
+        where: { id: toolId },
       });
       return c.json({ tool });
     }


### PR DESCRIPTION
Closes #29

Four authz gaps hardened:

- **tools.patch**, **api-keys.delete**, **access-tokens.revoke** now use `updateMany` / `deleteMany` with a compound `{ id, serverId }` predicate; if the row doesn't belong to the loaded server the response is 404 instead of a silent cross-tenant write.
- **orgs.GET /:orgId/members** requires the caller to be a member of the target org before returning any data.