### PR TITLE
fix(dashboard): paramName validation, slug sync, new-server org guard

### DIFF
--- a/app/(dashboard)/servers/new/page.tsx
+++ b/app/(dashboard)/servers/new/page.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from "next";
 import { NewServerWizard } from "@/components/dashboard/new-server-wizard";
+import { requireOrgSession } from "@/server/session";
 
 export const metadata: Metadata = { title: "New server" };
+export const dynamic = "force-dynamic";
 
-export default function NewServerPage() {
+export default async function NewServerPage() {
+  // Every mutation in the wizard hits `/api/openapi/*` and `/api/servers`,
+  // both of which require an active organization. Redirect to onboarding
+  // up-front so users without an org don't click Import and get 400s.
+  await requireOrgSession();
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <div>

--- a/src/components/dashboard/api-keys-panel.tsx
+++ b/src/components/dashboard/api-keys-panel.tsx
@@ -179,13 +179,26 @@ export function ApiKeysPanel({
             </div>
             {(form.type === "HEADER" || form.type === "QUERY") && (
               <div className="space-y-2">
-                <Label htmlFor="k-param">Parameter name</Label>
+                <Label htmlFor="k-param">
+                  Parameter name <span className="text-destructive">*</span>
+                </Label>
                 <Input
                   id="k-param"
                   value={form.paramName}
                   onChange={(e) => setForm({ ...form, paramName: e.target.value })}
                   placeholder="X-API-Key"
+                  required
+                  aria-invalid={
+                    (form.type === "HEADER" || form.type === "QUERY") &&
+                    !form.paramName
+                      ? true
+                      : undefined
+                  }
                 />
+                <p className="text-xs text-muted-foreground">
+                  Required for {form.type.toLowerCase()} credentials —
+                  without it the secret will never be injected.
+                </p>
               </div>
             )}
             <div className="space-y-2">
@@ -217,7 +230,15 @@ export function ApiKeysPanel({
             </Button>
             <Button
               onClick={create}
-              disabled={pending || !form.name || !form.secret}
+              disabled={
+                pending ||
+                !form.name ||
+                !form.secret ||
+                // HEADER/QUERY secrets without a paramName can never be
+                // injected — block the save instead of storing dead data.
+                ((form.type === "HEADER" || form.type === "QUERY") &&
+                  !form.paramName)
+              }
             >
               Save (encrypted)
             </Button>

--- a/src/components/dashboard/onboarding-form.tsx
+++ b/src/components/dashboard/onboarding-form.tsx
@@ -14,8 +14,17 @@ import { slugify } from "@/lib/utils";
 export function OnboardingForm() {
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  // Tracks whether the user has manually edited the slug. Until they
+  // do, we keep the slug in sync with the workspace name so a partial
+  // slug doesn't get submitted.
+  const [slugTouched, setSlugTouched] = useState(false);
   const [pending, start] = useTransition();
   const router = useRouter();
+
+  const onNameChange = (next: string) => {
+    setName(next);
+    if (!slugTouched) setSlug(slugify(next));
+  };
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,10 +50,7 @@ export function OnboardingForm() {
           id="on-name"
           required
           value={name}
-          onChange={(e) => {
-            setName(e.target.value);
-            if (!slug) setSlug(slugify(e.target.value));
-          }}
+          onChange={(e) => onNameChange(e.target.value)}
           placeholder="Acme Labs"
         />
       </div>
@@ -53,7 +59,10 @@ export function OnboardingForm() {
         <Input
           id="on-slug"
           value={slug}
-          onChange={(e) => setSlug(e.target.value)}
+          onChange={(e) => {
+            setSlug(e.target.value);
+            setSlugTouched(true);
+          }}
           placeholder="acme-labs"
         />
       </div>


### PR DESCRIPTION
Closes #35

Three small dashboard robustness fixes that were flagged on PR #16:

- **`api-keys-panel`** disables Save and shows a required-field hint when `HEADER` / `QUERY` credentials have no paramName (they would otherwise be dead data per `executor.ts:applyAuth`).
- **`onboarding-form`** tracks whether the user edited the slug; otherwise the slug stays in sync with the name instead of freezing after the first keystroke.
- **`servers/new/page.tsx`** awaits `requireOrgSession()` so users without an active org are sent to onboarding instead of hitting 400s in the wizard.