### PR TITLE
refactor(icons): migrate to phosphor-icons v2 aliased names

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Plug } from "@phosphor-icons/react/dist/ssr";
+import { PlugIcon } from "@phosphor-icons/react/dist/ssr";
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -7,7 +7,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       <div className="absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_top,theme(colors.primary/10),transparent_60%)]" />
       <header className="container mx-auto flex h-14 items-center px-4">
         <Link href="/" className="flex items-center gap-2 font-semibold">
-          <Plug weight="duotone" className="h-5 w-5 text-primary" />
+          <PlugIcon weight="duotone" className="h-5 w-5 text-primary" />
           oh-my-mcp
         </Link>
       </header>

--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Plug } from "@phosphor-icons/react/dist/ssr";
+import { PlugIcon } from "@phosphor-icons/react/dist/ssr";
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -8,7 +8,7 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
       <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur">
         <div className="container mx-auto flex h-14 items-center justify-between px-4">
           <Link href="/" className="flex items-center gap-2 font-semibold">
-            <Plug weight="duotone" className="h-5 w-5 text-primary" />
+            <PlugIcon weight="duotone" className="h-5 w-5 text-primary" />
             oh-my-mcp
           </Link>
           <nav className="hidden items-center gap-6 text-sm text-muted-foreground md:flex">

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { GithubLogo, GoogleLogo, ArrowRight } from "@phosphor-icons/react/dist/ssr";
+import { GithubLogoIcon, GoogleLogoIcon, ArrowRightIcon } from "@phosphor-icons/react/dist/ssr";
 
 export function SignInForm() {
   const [email, setEmail] = useState("");
@@ -71,7 +71,7 @@ export function SignInForm() {
         </div>
         <Button type="submit" className="w-full" disabled={pending}>
           {pending ? "Signing in…" : "Sign in"}
-          <ArrowRight className="ml-1 h-4 w-4" />
+          <ArrowRightIcon className="ml-1 h-4 w-4" />
         </Button>
       </form>
 
@@ -89,7 +89,7 @@ export function SignInForm() {
           onClick={() => onSocial("github")}
           disabled={pending}
         >
-          <GithubLogo weight="fill" /> GitHub
+          <GithubLogoIcon weight="fill" /> GitHub
         </Button>
         <Button
           type="button"
@@ -97,7 +97,7 @@ export function SignInForm() {
           onClick={() => onSocial("google")}
           disabled={pending}
         >
-          <GoogleLogo weight="fill" /> Google
+          <GoogleLogoIcon weight="fill" /> Google
         </Button>
       </div>
     </div>

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -3,22 +3,22 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
-  House,
-  Stack,
-  Users,
-  GearSix,
-  Plug,
-  Plus,
+  HouseIcon,
+  StackIcon,
+  UsersIcon,
+  GearSixIcon,
+  PlugIcon,
+  PlusIcon,
 } from "@phosphor-icons/react/dist/ssr";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
 const nav = [
-  { href: "/dashboard", label: "Overview", icon: House },
-  { href: "/servers", label: "Servers", icon: Stack },
-  { href: "/org", label: "Organization", icon: Users },
-  { href: "/account", label: "Account", icon: GearSix },
+  { href: "/dashboard", label: "Overview", icon: HouseIcon },
+  { href: "/servers", label: "Servers", icon: StackIcon },
+  { href: "/org", label: "Organization", icon: UsersIcon },
+  { href: "/account", label: "Account", icon: GearSixIcon },
 ];
 
 export function Sidebar() {
@@ -26,13 +26,13 @@ export function Sidebar() {
   return (
     <aside className="hidden w-60 shrink-0 border-r bg-card/30 md:flex md:flex-col">
       <div className="flex h-14 items-center gap-2 border-b px-4 font-semibold">
-        <Plug weight="duotone" className="h-5 w-5 text-primary" />
+        <PlugIcon weight="duotone" className="h-5 w-5 text-primary" />
         oh-my-mcp
       </div>
       <div className="flex-1 space-y-1 p-3">
         <Button asChild size="sm" className="mb-3 w-full justify-start gap-2">
           <Link href="/servers/new">
-            <Plus className="h-4 w-4" /> New server
+            <PlusIcon className="h-4 w-4" /> New server
           </Link>
         </Button>
         {nav.map((item) => {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { X } from "@phosphor-icons/react/dist/ssr";
+import { XIcon } from "@phosphor-icons/react/dist/ssr";
 
 import { cn } from "@/lib/utils";
 
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-        <X className="h-4 w-4" />
+        <XIcon className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { Check, CaretRight, Circle } from "@phosphor-icons/react/dist/ssr";
+import { CheckIcon, CaretRightIcon, CircleIcon } from "@phosphor-icons/react/dist/ssr";
 
 import { cn } from "@/lib/utils";
 
@@ -29,7 +29,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <CaretRight className="ml-auto" />
+    <CaretRightIcon className="ml-auto" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
@@ -101,7 +101,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <CheckIcon className="h-4 w-4" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <CircleIcon className="h-2 w-2 fill-current" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}


### PR DESCRIPTION
Closes #41

Mechanical rename of Phosphor icon imports and their JSX usages to the v2 aliased names (`X` -> `XIcon`, etc.). Only the 6 files whose entire diff is icon-only; mixed files will get their icons updated as part of the feature PR that also touches them.