### PR TITLE
feat(lib): typed RPC namespace + toast helpers + shared utils + schemas

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { api } from "./rpc";
+
+export { api };
+
+/** Pre-bound sub-client for per-server routes. Callers still pass
+ * `param: { serverId }`, but the Hono-RPC template string stays in one place. */
+export const serverRpc = api.servers[":serverId"];
+
+interface MutateOptions {
+  /** Override the toast message when the server did not return one. */
+  error?: string;
+  /** Show a success toast when the request resolves 2xx. */
+  success?: string;
+  /** Suppress toasts entirely; the caller takes full responsibility for UX. */
+  silent?: boolean;
+}
+
+/**
+ * Thin wrapper around a typed Hono RPC call.
+ *
+ * On non-2xx it surfaces the server-provided `message` as a toast and
+ * returns `null`; on success it returns the parsed body. Callers should
+ * narrow the generic `T` to the known response shape of the endpoint.
+ */
+export async function apiMutate<T>(
+  run: () => Promise<Response>,
+  options?: MutateOptions
+): Promise<T | null> {
+  try {
+    const res = await run();
+    if (!res.ok) {
+      if (!options?.silent) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string };
+        toast.error(body.message ?? options?.error ?? "Something went wrong.");
+      }
+      return null;
+    }
+    const data = (await res.json()) as T;
+    if (options?.success) toast.success(options.success);
+    return data;
+  } catch (err) {
+    if (!options?.silent) {
+      toast.error(
+        options?.error ?? (err instanceof Error ? err.message : "Request failed.")
+      );
+    }
+    return null;
+  }
+}
+
+/**
+ * Same toast semantics as `apiMutate`, but for fire-and-forget calls where
+ * the caller only cares whether the request succeeded. Returns `true` on
+ * 2xx, `false` otherwise.
+ */
+export async function apiAction(
+  run: () => Promise<Response>,
+  options?: MutateOptions
+): Promise<boolean> {
+  const result = await apiMutate<unknown>(run, options);
+  return result !== null;
+}

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,27 +1,25 @@
 import { hc } from "hono/client";
 import type { AppType } from "@/server/hono";
+import { getAppOrigin } from "@/lib/utils";
 
 /**
  * Typed Hono RPC client. Usage:
  *
- *   const { data } = await api.me.$get().then((r) => r.json());
+ *   const res = await api.me.$get();
+ *
+ * The Hono app is mounted with `basePath("/api")`, so `hc<AppType>` exposes
+ * the route tree under `.api`. We strip that prefix here so callers can
+ * write `api.servers.*` instead of `api.api.servers.*`.
  */
 export function getRpc(baseUrl?: string) {
-  const origin =
-    baseUrl ??
-    (typeof window !== "undefined"
-      ? window.location.origin
-      : process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000");
-  // The Hono app is mounted with basePath("/api"), so we pass the bare origin
-  // here — `hc` already folds the basePath into the client tree.
-  return hc<AppType>(origin, {
+  return hc<AppType>(baseUrl ?? getAppOrigin(), {
     fetch: ((input: RequestInfo | URL, init?: RequestInit) =>
       fetch(input, {
         ...init,
         // Always include cookies for same-origin calls (auth session).
         credentials: "include",
       })) as typeof fetch,
-  });
+  }).api;
 }
 
 export const api = getRpc();

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -44,6 +44,13 @@ export const ingestFromTextSchema = z.object({
   source: openApiSourceEnum.default("PASTE"),
 });
 
+// ---- Quick create (one-shot: ingest + create server) ----
+
+export const quickCreateServerSchema = z.object({
+  // URL or raw OpenAPI document (JSON/YAML). We detect which at runtime.
+  input: z.string().min(1).max(5_000_000),
+});
+
 // ---- Tools ----
 
 export const updateToolSchema = z.object({
@@ -80,12 +87,22 @@ export const inviteMemberSchema = z.object({
   role: z.enum(["owner", "admin", "member"]).default("member"),
 });
 
+export const setActiveOrgSchema = z.object({
+  orgId: cuid,
+});
+
 export type CreateServerInput = z.infer<typeof createServerSchema>;
 export type UpdateServerInput = z.infer<typeof updateServerSchema>;
 export type IngestFromUrlInput = z.infer<typeof ingestFromUrlSchema>;
 export type IngestFromTextInput = z.infer<typeof ingestFromTextSchema>;
+export type QuickCreateServerInput = z.infer<typeof quickCreateServerSchema>;
 export type UpdateToolInput = z.infer<typeof updateToolSchema>;
 export type CreateApiKeyInput = z.infer<typeof createApiKeySchema>;
 export type CreateAccessTokenInput = z.infer<typeof createAccessTokenSchema>;
 export type CreateOrgInput = z.infer<typeof createOrgSchema>;
 export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;
+export type SetActiveOrgInput = z.infer<typeof setActiveOrgSchema>;
+
+export type Visibility = z.infer<typeof visibilityEnum>;
+export type AuthType = z.infer<typeof authTypeEnum>;
+export type OpenApiSource = z.infer<typeof openApiSourceEnum>;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,9 +15,49 @@ export function slugify(input: string): string {
     .slice(0, 64);
 }
 
+/**
+ * Single source of truth for the app origin. Prefers the browser location
+ * when available so client-rendered URLs match the tab the user is on,
+ * falls back to `NEXT_PUBLIC_APP_URL`, and finally to `localhost:3000` for
+ * the build-time / test case where neither is present.
+ */
+export function getAppOrigin(): string {
+  if (typeof window !== "undefined") return window.location.origin;
+  return process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+}
+
 export function absoluteUrl(path: string): string {
-  const base =
-    process.env.NEXT_PUBLIC_APP_URL ??
-    (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
-  return `${base.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
+  const base = getAppOrigin().replace(/\/$/, "");
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export function mcpUrlFor(slug: string): string {
+  return `${getAppOrigin()}/mcp/${slug}`;
+}
+
+export function initialsOf(name: string, max = 2): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, max)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+export function randomSuffix(n: number): string {
+  return Math.random().toString(36).slice(2, 2 + n);
+}
+
+export function looksLikeUrl(s: string): boolean {
+  if (!/^https?:\/\//i.test(s)) return false;
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function slugCandidates(base: string, lengths: number[] = [4, 6, 8]): string[] {
+  return [base, ...lengths.map((n) => `${base}-${randomSuffix(n)}`)];
 }


### PR DESCRIPTION
Closes #43

Adds the client-side building blocks the forthcoming dashboard PRs will rely on:

- `src/lib/rpc.ts` — namespace fix (`.api` suffix) + centralised origin
- `src/lib/api.ts` — `apiMutate` / `apiAction` + `serverRpc`
- `src/lib/utils.ts` — `getAppOrigin`, `mcpUrlFor`, `initialsOf`, `randomSuffix`, `looksLikeUrl`, `slugCandidates`
- `src/lib/schemas/index.ts` — `quickCreateServerSchema`, `setActiveOrgSchema`, type re-exports

Pure additions, no consumers migrate here — the UI rewrites land in subsequent PRs.