### PR TITLE
feat(api): canonical REST route names on Hono routers

### DIFF
--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -23,7 +23,7 @@ const base = new Hono<Env>()
   .basePath("/api")
   .use("*", logger())
   .use("*", async (c, next) => {
-    const url = c.env.DATABASE_URL ?? process.env.DATABASE_URL;
+    const url = c.env?.DATABASE_URL ?? process.env.DATABASE_URL;
     const db = getDb(url);
     const auth = createAuth(url);
     c.set("db", db);

--- a/src/server/routers/access-tokens.ts
+++ b/src/server/routers/access-tokens.ts
@@ -18,7 +18,7 @@ export const accessTokensRouter = new Hono<Env>()
   .get("/", async (c) => {
     const serverId = c.req.param("serverId")!;
     const server = await loadServer(c, serverId);
-    const tokens = await c.var.db.mcpAccessToken.findMany({
+    const accessTokens = await c.var.db.mcpAccessToken.findMany({
       where: { serverId: server.id },
       select: {
         id: true,
@@ -31,7 +31,7 @@ export const accessTokensRouter = new Hono<Env>()
       },
       orderBy: { createdAt: "desc" },
     });
-    return c.json({ tokens });
+    return c.json({ accessTokens });
   })
 
   .post("/", zValidator("json", createAccessTokenSchema), async (c) => {
@@ -58,7 +58,7 @@ export const accessTokensRouter = new Hono<Env>()
       },
     });
     // Only time the raw token is returned.
-    return c.json({ token: created, raw }, 201);
+    return c.json({ accessToken: created, raw }, 201);
   })
 
   .post("/:tokenId/revoke", async (c) => {

--- a/src/server/routers/api-keys.ts
+++ b/src/server/routers/api-keys.ts
@@ -18,7 +18,7 @@ export const apiKeysRouter = new Hono<Env>()
   .get("/", async (c) => {
     const serverId = c.req.param("serverId")!;
     const server = await loadServer(c, serverId);
-    const keys = await c.var.db.mcpApiKey.findMany({
+    const apiKeys = await c.var.db.mcpApiKey.findMany({
       where: { serverId: server.id },
       select: {
         id: true,
@@ -30,7 +30,7 @@ export const apiKeysRouter = new Hono<Env>()
       },
       orderBy: { createdAt: "desc" },
     });
-    return c.json({ keys });
+    return c.json({ apiKeys });
   })
 
   .post("/", zValidator("json", createApiKeySchema), async (c) => {
@@ -62,7 +62,7 @@ export const apiKeysRouter = new Hono<Env>()
         createdAt: true,
       },
     });
-    return c.json({ key: created }, 201);
+    return c.json({ apiKey: created }, 201);
   })
 
   .delete("/:keyId", async (c) => {

--- a/src/server/routers/openapi.ts
+++ b/src/server/routers/openapi.ts
@@ -20,7 +20,7 @@ export const openApiRouter = new Hono<Env>()
   .use("*", requireOrg)
 
   .get("/", async (c) => {
-    const docs = await c.var.db.openApiDoc.findMany({
+    const openApiDocs = await c.var.db.openApiDoc.findMany({
       where: { organizationId: c.var.orgId! },
       select: {
         id: true,
@@ -32,7 +32,7 @@ export const openApiRouter = new Hono<Env>()
       },
       orderBy: { createdAt: "desc" },
     });
-    return c.json({ docs });
+    return c.json({ openApiDocs });
   })
 
   .post("/from-url", zValidator("json", ingestFromUrlSchema), async (c) => {
@@ -65,21 +65,23 @@ export const openApiRouter = new Hono<Env>()
     return await persist(c, doc, { source: "UPLOAD", sourceUrl: null });
   })
 
-  .get("/:id", async (c) => {
-    const id = c.req.param("id");
+  .get("/:docId", async (c) => {
+    const docId = c.req.param("docId");
     const doc = await c.var.db.openApiDoc.findFirst({
-      where: { id, organizationId: c.var.orgId! },
+      where: { id: docId, organizationId: c.var.orgId! },
     });
     if (!doc) throw new HTTPException(404, { message: "Not found." });
     const preview = compileOpenApiToTools(doc.rawJson as unknown);
     return c.json({
-      id: doc.id,
-      title: doc.title,
-      version: doc.version,
-      source: doc.source,
-      sourceUrl: doc.sourceUrl,
-      toolCount: preview.tools.length,
-      baseUrl: preview.info.baseUrl,
+      openApiDoc: {
+        id: doc.id,
+        title: doc.title,
+        version: doc.version,
+        source: doc.source,
+        sourceUrl: doc.sourceUrl,
+        toolCount: preview.tools.length,
+        baseUrl: preview.info.baseUrl,
+      },
     });
   });
 
@@ -107,7 +109,7 @@ async function persist(
     });
     return c.json(
       {
-        doc: {
+        openApiDoc: {
           id: created.id,
           title: created.title,
           version: created.version,
@@ -124,7 +126,7 @@ async function persist(
       });
       if (existing) {
         return c.json({
-          doc: {
+          openApiDoc: {
             id: existing.id,
             title: existing.title,
             version: existing.version,

--- a/src/server/routers/orgs.ts
+++ b/src/server/routers/orgs.ts
@@ -4,7 +4,7 @@ import { zValidator } from "@hono/zod-validator";
 
 import type { Env } from "../context";
 import { requireAuth } from "../guards";
-import { createOrgSchema, inviteMemberSchema } from "@/lib/schemas";
+import { createOrgSchema, inviteMemberSchema, setActiveOrgSchema } from "@/lib/schemas";
 
 export const orgsRouter = new Hono<Env>()
   .use("*", requireAuth)
@@ -29,16 +29,25 @@ export const orgsRouter = new Hono<Env>()
 
   .post("/", zValidator("json", createOrgSchema), async (c) => {
     const body = c.req.valid("json");
-    const res = await c.var.auth.api.createOrganization({
-      body: { name: body.name, slug: body.slug },
-      headers: c.req.raw.headers,
-    });
-    if (!res) throw new HTTPException(400, { message: "Could not create organization." });
-    return c.json({ organization: res }, 201);
+    try {
+      const res = await c.var.auth.api.createOrganization({
+        body: { name: body.name, slug: body.slug },
+        headers: c.req.raw.headers,
+      });
+      if (!res) throw new HTTPException(400, { message: "Could not create organization." });
+      return c.json({ organization: res }, 201);
+    } catch (err) {
+      if (err instanceof HTTPException) throw err;
+      // better-auth throws on slug collisions and similar; surface the
+      // underlying message as a 409 so clients (sign-up retry loop, UI
+      // toasts) can distinguish it from a true server error.
+      const msg = err instanceof Error ? err.message : "Could not create organization.";
+      throw new HTTPException(409, { message: msg });
+    }
   })
 
-  .post("/:orgId/set-active", async (c) => {
-    const orgId = c.req.param("orgId");
+  .post("/active", zValidator("json", setActiveOrgSchema), async (c) => {
+    const { orgId } = c.req.valid("json");
     await c.var.auth.api.setActiveOrganization({
       body: { organizationId: orgId },
       headers: c.req.raw.headers,
@@ -66,7 +75,7 @@ export const orgsRouter = new Hono<Env>()
   })
 
   .post(
-    "/:orgId/invite",
+    "/:orgId/invitations",
     zValidator("json", inviteMemberSchema),
     async (c) => {
       const orgId = c.req.param("orgId");

--- a/src/server/routers/servers.ts
+++ b/src/server/routers/servers.ts
@@ -82,11 +82,11 @@ export const serversRouter = new Hono<Env>()
     }
   })
 
-  .get("/:id", async (c) => {
-    const id = c.req.param("id");
+  .get("/:serverId", async (c) => {
+    const serverId = c.req.param("serverId");
     const orgId = c.var.orgId!;
     const server = await c.var.db.mcpServer.findFirst({
-      where: { id, organizationId: orgId },
+      where: { id: serverId, organizationId: orgId },
       include: {
         openApiDoc: { select: { id: true, title: true, version: true } },
         _count: { select: { tools: true, apiKeys: true, accessTokens: true } },
@@ -96,13 +96,13 @@ export const serversRouter = new Hono<Env>()
     return c.json({ server });
   })
 
-  .patch("/:id", zValidator("json", updateServerSchema), async (c) => {
-    const id = c.req.param("id");
+  .patch("/:serverId", zValidator("json", updateServerSchema), async (c) => {
+    const serverId = c.req.param("serverId");
     const orgId = c.var.orgId!;
     const body = c.req.valid("json");
     try {
       const updated = await c.var.db.mcpServer.update({
-        where: { id, organizationId: orgId },
+        where: { id: serverId, organizationId: orgId },
         data: {
           ...(body.name !== undefined ? { name: body.name } : {}),
           ...(body.slug !== undefined ? { slug: body.slug } : {}),
@@ -126,10 +126,10 @@ export const serversRouter = new Hono<Env>()
     }
   })
 
-  .delete("/:id", async (c) => {
-    const id = c.req.param("id");
+  .delete("/:serverId", async (c) => {
+    const serverId = c.req.param("serverId");
     const orgId = c.var.orgId!;
-    await c.var.db.mcpServer.delete({ where: { id, organizationId: orgId } });
+    await c.var.db.mcpServer.delete({ where: { id: serverId, organizationId: orgId } });
     return c.json({ ok: true });
   });
 


### PR DESCRIPTION
Closes #47

Path-param and response-key tidy-up before the dashboard UI starts calling these via the typed RPC client.

- `servers`: `:id` → `:serverId`
- `openapi`: `:id` → `:docId` + `doc`/`docs` → `openApiDoc`/`openApiDocs`
- `orgs`: `/:orgId/set-active` → `/active` (body), `/invite` → `/invitations`, slug collision mapped to 409
- `api-keys`, `access-tokens`: list responses renamed to `apiKeys`/`accessTokens`
- `hono.ts`: `c.env?.DATABASE_URL` for RSC build paths

No UI consumers migrate here.