### PR TITLE
feat(dashboard): quick-create server flow + auth/onboarding forms migration

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Stack, Users, Key, Lightning } from "@phosphor-icons/react/dist/ssr";
+import { ArrowRightIcon, StackIcon, UsersIcon, KeyIcon, LightningIcon } from "@phosphor-icons/react/dist/ssr";
 
 import { getDashboardContext } from "@/server/session";
 import { Button } from "@/components/ui/button";
@@ -27,10 +27,10 @@ export default async function OverviewPage() {
   ]);
 
   const stats = [
-    { label: "Servers", value: serverCount, icon: Stack },
-    { label: "Tools", value: toolCount, icon: Lightning },
-    { label: "Upstream keys", value: keyCount, icon: Key },
-    { label: "Access tokens", value: tokenCount, icon: Users },
+    { label: "Servers", value: serverCount, icon: StackIcon },
+    { label: "Tools", value: toolCount, icon: LightningIcon },
+    { label: "Upstream keys", value: keyCount, icon: KeyIcon },
+    { label: "Access tokens", value: tokenCount, icon: UsersIcon },
   ];
 
   return (
@@ -44,7 +44,7 @@ export default async function OverviewPage() {
         </div>
         <Button asChild>
           <Link href="/servers/new">
-            New server <ArrowRight className="ml-1 h-4 w-4" />
+            New server <ArrowRightIcon className="ml-1 h-4 w-4" />
           </Link>
         </Button>
       </div>
@@ -102,13 +102,13 @@ export default async function OverviewPage() {
 function EmptyState() {
   return (
     <div className="flex flex-col items-center gap-4 py-10 text-center">
-      <Stack weight="duotone" className="h-10 w-10 text-muted-foreground" />
+      <StackIcon weight="duotone" className="h-10 w-10 text-muted-foreground" />
       <p className="text-sm text-muted-foreground">
-        No servers yet. Import an OpenAPI doc to get started.
+        Paste an OpenAPI URL to create your first MCP server.
       </p>
       <Button asChild>
         <Link href="/servers/new">
-          Create your first server <ArrowRight className="ml-1 h-4 w-4" />
+          Create your first server <ArrowRightIcon className="ml-1 h-4 w-4" />
         </Link>
       </Button>
     </div>

--- a/app/(dashboard)/servers/new/page.tsx
+++ b/app/(dashboard)/servers/new/page.tsx
@@ -6,16 +6,15 @@ export const metadata: Metadata = { title: "New server" };
 export const dynamic = "force-dynamic";
 
 export default async function NewServerPage() {
-  // Every mutation in the wizard hits `/api/openapi/*` and `/api/servers`,
-  // both of which require an active organization. Redirect to onboarding
-  // up-front so users without an org don't click Import and get 400s.
+  // The quick-create endpoint requires an active organization. Ensure one
+  // exists up-front so the user never sees a 400 on submit.
   await requireOrgSession();
   return (
     <div className="mx-auto max-w-3xl space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold">Create MCP server</h1>
+        <h1 className="text-2xl font-semibold">New MCP server</h1>
         <p className="text-sm text-muted-foreground">
-          Import an OpenAPI document and pick which operations become tools.
+          Paste an OpenAPI URL or document and we&apos;ll host the MCP endpoint.
         </p>
       </div>
       <NewServerWizard />

--- a/src/components/auth/sign-up-form.tsx
+++ b/src/components/auth/sign-up-form.tsx
@@ -4,18 +4,18 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { signUp, organization } from "@/lib/auth-client";
+import { signUp } from "@/lib/auth-client";
+import { api, apiAction, apiMutate } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ArrowRight } from "@phosphor-icons/react/dist/ssr";
-import { slugify } from "@/lib/utils";
+import { ArrowRightIcon } from "@phosphor-icons/react/dist/ssr";
+import { randomSuffix, slugCandidates, slugify } from "@/lib/utils";
 
 export function SignUpForm() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [workspace, setWorkspace] = useState("");
   const [pending, startTransition] = useTransition();
   const router = useRouter();
 
@@ -27,45 +27,40 @@ export function SignUpForm() {
         toast.error(error.message ?? "Sign up failed.");
         return;
       }
-      // Auto-create the first organization from the workspace name.
-      // Common names (e.g. "Acme") collide on the unique slug constraint,
-      // so we retry with a short random suffix before giving up.
-      const orgName = workspace.trim() || `${name.split(" ")[0]}'s Workspace`;
-      const baseSlug = slugify(orgName) || `ws-${Math.random().toString(36).slice(2, 8)}`;
-      const slugCandidates = [
-        baseSlug,
-        `${baseSlug}-${Math.random().toString(36).slice(2, 6)}`,
-        `${baseSlug}-${Math.random().toString(36).slice(2, 10)}`,
-      ];
+      // Auto-create a personal workspace from the user's name. Slug
+      // collisions across all orgs are disambiguated with short random
+      // suffixes before we give up.
+      const firstName = name.split(" ")[0] || "my";
+      const orgName = `${firstName}'s Workspace`;
+      const baseSlug = slugify(orgName) || `ws-${randomSuffix(6)}`;
 
       let createdOrgId: string | null = null;
-      let lastError: { message?: string } | null = null;
-      for (const slug of slugCandidates) {
-        const { data: org, error: orgErr } = await organization.create({
-          name: orgName,
-          slug,
-        });
-        if (!orgErr && org?.id) {
-          createdOrgId = org.id;
+      for (const slug of slugCandidates(baseSlug)) {
+        const data = await apiMutate<{ organization: { id: string } }>(
+          () => api.orgs.$post({ json: { name: orgName, slug } }),
+          { silent: true }
+        );
+        if (data?.organization?.id) {
+          createdOrgId = data.organization.id;
           break;
         }
-        lastError = orgErr ?? null;
       }
 
       if (!createdOrgId) {
-        // Account exists; user can pick a slug manually on the
-        // onboarding page instead of being stranded here.
-        toast.error(
-          lastError?.message
-            ? `Workspace name taken — pick another on the next screen.`
-            : "Could not create workspace automatically."
-        );
-        router.push("/dashboard/onboarding");
+        // Extremely rare: three random slugs collided. The server-side
+        // `requireOrgSession` will create one for us on the next request,
+        // so just land the user on the dashboard instead of stranding
+        // them on an onboarding page they don't need.
+        toast.success("Welcome aboard!");
+        router.push("/dashboard");
         router.refresh();
         return;
       }
 
-      await organization.setActive({ organizationId: createdOrgId });
+      await apiAction(
+        () => api.orgs.active.$post({ json: { orgId: createdOrgId! } }),
+        { silent: true }
+      );
       toast.success("Welcome aboard!");
       router.push("/dashboard");
       router.refresh();
@@ -83,15 +78,6 @@ export function SignUpForm() {
           onChange={(e) => setName(e.target.value)}
           placeholder="Ada Lovelace"
           autoComplete="name"
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="workspace">Workspace name</Label>
-        <Input
-          id="workspace"
-          value={workspace}
-          onChange={(e) => setWorkspace(e.target.value)}
-          placeholder="Acme Labs"
         />
       </div>
       <div className="space-y-2">
@@ -119,8 +105,8 @@ export function SignUpForm() {
         />
       </div>
       <Button type="submit" className="w-full" disabled={pending}>
-        {pending ? "Creating workspace…" : "Create account"}
-        <ArrowRight className="ml-1 h-4 w-4" />
+        {pending ? "Creating account…" : "Create account"}
+        <ArrowRightIcon className="ml-1 h-4 w-4" />
       </Button>
     </form>
   );

--- a/src/components/dashboard/new-server-wizard.tsx
+++ b/src/components/dashboard/new-server-wizard.tsx
@@ -2,281 +2,94 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
-import {
-  ArrowRight,
-  CheckCircle,
-  CloudArrowUp,
-  FileText,
-  LinkSimple,
-} from "@phosphor-icons/react/dist/ssr";
+import { ArrowRightIcon, LinkSimpleIcon } from "@phosphor-icons/react/dist/ssr";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { slugify } from "@/lib/utils";
+import { api, apiMutate } from "@/lib/api";
+import { looksLikeUrl } from "@/lib/utils";
 
-type IngestResult = {
-  id: string;
-  title: string;
-  version: string;
-  toolCount: number;
-  baseUrl: string | null;
-};
-
+/**
+ * Single-input "smart" create form. Accepts either an OpenAPI URL or a
+ * pasted JSON/YAML document and hands both to the `/servers/quick-create`
+ * endpoint, which auto-derives name, slug, and baseUrl from the spec.
+ */
 export function NewServerWizard() {
-  const [step, setStep] = useState<1 | 2>(1);
-  const [pending, start] = useTransition();
-  const [doc, setDoc] = useState<IngestResult | null>(null);
-
-  // Step 1 inputs
-  const [url, setUrl] = useState("");
-  const [text, setText] = useState("");
-  const [file, setFile] = useState<File | null>(null);
-
-  // Step 2 inputs
-  const [name, setName] = useState("");
-  const [slug, setSlug] = useState("");
-  const [description, setDescription] = useState("");
-  const [baseUrl, setBaseUrl] = useState("");
-  const [visibility, setVisibility] = useState<"PRIVATE" | "UNLISTED" | "PUBLIC">(
-    "PRIVATE"
-  );
-
+  const [input, setInput] = useState("");
+  const [pending, startTransition] = useTransition();
   const router = useRouter();
 
-  const ingestUrl = () => {
-    if (!url) return;
-    start(async () => {
-      const res = await fetch("/api/openapi/from-url", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ url }),
-        credentials: "include",
-      });
-      await handleIngest(res);
-    });
-  };
-
-  const ingestText = () => {
-    if (!text) return;
-    start(async () => {
-      const res = await fetch("/api/openapi/from-text", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content: text, source: "PASTE" }),
-        credentials: "include",
-      });
-      await handleIngest(res);
-    });
-  };
-
-  const ingestFile = () => {
-    if (!file) return;
-    start(async () => {
-      const fd = new FormData();
-      fd.append("file", file);
-      const res = await fetch("/api/openapi/from-file", {
-        method: "POST",
-        body: fd,
-        credentials: "include",
-      });
-      await handleIngest(res);
-    });
-  };
-
-  const handleIngest = async (res: Response) => {
-    if (!res.ok) {
-      const data = (await res.json().catch(() => ({}))) as { message?: string };
-      toast.error(data?.message ?? "Failed to import OpenAPI document.");
-      return;
-    }
-    const { doc: d } = (await res.json()) as { doc: IngestResult };
-    setDoc(d);
-    setName(d.title);
-    setSlug(slugify(d.title));
-    setBaseUrl(d.baseUrl ?? "");
-    setStep(2);
-  };
-
-  const create = () => {
-    if (!doc) return;
-    start(async () => {
-      const res = await fetch("/api/servers", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          name,
-          slug,
-          description: description || null,
-          baseUrl: baseUrl || null,
-          visibility,
-          openApiDocId: doc.id,
-        }),
-        credentials: "include",
-      });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { message?: string };
-        toast.error(data?.message ?? "Could not create server.");
-        return;
+  const create = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    const value = input.trim();
+    if (!value) return;
+    startTransition(async () => {
+      const data = await apiMutate<{
+        server: { id: string; slug: string; name: string };
+        toolCount: number;
+      }>(
+        () =>
+          api.servers["quick-create"].$post({ json: { input: value } }),
+        {
+          error: "Could not create server.",
+          success: "MCP server is ready.",
+        }
+      );
+      if (data) {
+        router.push(`/servers/${data.server.id}`);
+        router.refresh();
       }
-      const { server } = (await res.json()) as { server: { id: string } };
-      toast.success("Server created.");
-      router.push(`/servers/${server.id}`);
-      router.refresh();
     });
   };
 
-  if (step === 2 && doc) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Configure server</CardTitle>
-          <CardDescription>
-            {doc.toolCount} tools discovered in {doc.title} v{doc.version}.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">Name</Label>
-            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="slug">Slug</Label>
-            <Input
-              id="slug"
-              value={slug}
-              onChange={(e) => setSlug(e.target.value)}
-            />
-            <p className="text-xs text-muted-foreground">
-              Your MCP endpoint will be{" "}
-              <span className="font-mono">
-                {typeof window !== "undefined" ? window.location.origin : ""}
-                /mcp/{slug || "…"}
-              </span>
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
-            <Textarea
-              id="description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Shown to agents as the server’s purpose."
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="baseUrl">Base URL</Label>
-            <Input
-              id="baseUrl"
-              value={baseUrl}
-              onChange={(e) => setBaseUrl(e.target.value)}
-              placeholder="https://api.example.com"
-            />
-            <p className="text-xs text-muted-foreground">
-              Defaults to the first <code>servers[]</code> entry in your spec.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label>Visibility</Label>
-            <div className="grid grid-cols-3 gap-2">
-              {(["PRIVATE", "UNLISTED", "PUBLIC"] as const).map((v) => (
-                <button
-                  type="button"
-                  key={v}
-                  onClick={() => setVisibility(v)}
-                  className={
-                    "rounded-md border px-3 py-2 text-sm transition-colors " +
-                    (visibility === v
-                      ? "border-primary bg-primary/10"
-                      : "hover:bg-accent")
-                  }
-                >
-                  {v.toLowerCase()}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="flex justify-between pt-2">
-            <Button variant="ghost" onClick={() => setStep(1)}>
-              Back
-            </Button>
-            <Button onClick={create} disabled={pending || !name || !slug}>
-              {pending ? "Creating…" : "Create server"}
-              <ArrowRight className="ml-1 h-4 w-4" />
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
+  const isUrl = looksLikeUrl(input.trim());
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Import OpenAPI</CardTitle>
+        <CardTitle>Paste an OpenAPI document</CardTitle>
         <CardDescription>
-          Supply a URL, paste JSON, or upload a file. JSON only for now — YAML coming soon.
+          URL or raw JSON / YAML — we handle the rest. Name, slug, and base
+          URL are derived from the spec.
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <Tabs defaultValue="url">
-          <TabsList>
-            <TabsTrigger value="url">
-              <LinkSimple className="h-4 w-4" /> URL
-            </TabsTrigger>
-            <TabsTrigger value="paste">
-              <FileText className="h-4 w-4" /> Paste
-            </TabsTrigger>
-            <TabsTrigger value="upload">
-              <CloudArrowUp className="h-4 w-4" /> Upload
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="url" className="space-y-3 pt-4">
-            <Input
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://petstore3.swagger.io/api/v3/openapi.json"
-            />
-            <Button onClick={ingestUrl} disabled={pending || !url}>
-              {pending ? "Fetching…" : "Import"}
+        <form onSubmit={create} className="space-y-4">
+          <Textarea
+            autoFocus
+            rows={8}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={
+              "https://petstore3.swagger.io/api/v3/openapi.json\n\n— or —\n\n{\n  \"openapi\": \"3.1.0\",\n  \"info\": { ... },\n  \"paths\": { ... }\n}"
+            }
+            className="min-h-[220px] font-mono text-xs"
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                create();
+              }
+            }}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1">
+              {isUrl ? (
+                <>
+                  <LinkSimpleIcon className="h-3 w-3" /> Detected URL — we&apos;ll fetch it.
+                </>
+              ) : input.trim() ? (
+                <>Detected raw document — parsing as JSON or YAML.</>
+              ) : (
+                <>Tip: press ⌘/Ctrl+Enter to create.</>
+              )}
+            </span>
+            <Button type="submit" disabled={pending || !input.trim()}>
+              {pending ? "Creating…" : "Create MCP server"}
+              <ArrowRightIcon className="ml-1 h-4 w-4" />
             </Button>
-          </TabsContent>
-
-          <TabsContent value="paste" className="space-y-3 pt-4">
-            <Textarea
-              rows={10}
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder='{"openapi":"3.1.0",...}'
-              className="font-mono text-xs"
-            />
-            <Button onClick={ingestText} disabled={pending || !text}>
-              {pending ? "Parsing…" : "Import"}
-            </Button>
-          </TabsContent>
-
-          <TabsContent value="upload" className="space-y-3 pt-4">
-            <Input
-              type="file"
-              accept="application/json,.json"
-              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-            />
-            {file ? (
-              <p className="flex items-center gap-2 text-sm text-muted-foreground">
-                <CheckCircle className="h-4 w-4 text-emerald-500" />
-                {file.name} · {(file.size / 1024).toFixed(1)} KB
-              </p>
-            ) : null}
-            <Button onClick={ingestFile} disabled={pending || !file}>
-              {pending ? "Uploading…" : "Import"}
-            </Button>
-          </TabsContent>
-        </Tabs>
+          </div>
+        </form>
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/onboarding-form.tsx
+++ b/src/components/dashboard/onboarding-form.tsx
@@ -2,10 +2,9 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
-import { ArrowRight } from "@phosphor-icons/react/dist/ssr";
+import { ArrowRightIcon } from "@phosphor-icons/react/dist/ssr";
 
-import { organization } from "@/lib/auth-client";
+import { api, apiAction, apiMutate } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -18,7 +17,7 @@ export function OnboardingForm() {
   // do, we keep the slug in sync with the workspace name so a partial
   // slug doesn't get submitted.
   const [slugTouched, setSlugTouched] = useState(false);
-  const [pending, start] = useTransition();
+  const [pending, startTransition] = useTransition();
   const router = useRouter();
 
   const onNameChange = (next: string) => {
@@ -28,15 +27,18 @@ export function OnboardingForm() {
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    start(async () => {
+    startTransition(async () => {
       const finalSlug = slug.trim() || slugify(name);
-      const { data, error } = await organization.create({ name, slug: finalSlug });
-      if (error) {
-        toast.error(error.message ?? "Could not create organization.");
-        return;
-      }
-      if (data?.id) await organization.setActive({ organizationId: data.id });
-      toast.success("Workspace ready.");
+      const data = await apiMutate<{ organization: { id: string } }>(
+        () => api.orgs.$post({ json: { name, slug: finalSlug } }),
+        { error: "Could not create organization." }
+      );
+      if (!data) return;
+      const ok = await apiAction(
+        () => api.orgs.active.$post({ json: { orgId: data.organization.id } }),
+        { error: "Could not activate workspace.", success: "Workspace ready." }
+      );
+      if (!ok) return;
       router.push("/dashboard");
       router.refresh();
     });
@@ -68,7 +70,7 @@ export function OnboardingForm() {
       </div>
       <Button type="submit" className="w-full" disabled={pending || !name}>
         {pending ? "Creating…" : "Create workspace"}
-        <ArrowRight className="ml-1 h-4 w-4" />
+        <ArrowRightIcon className="ml-1 h-4 w-4" />
       </Button>
     </form>
   );

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,22 +1,16 @@
 "use client";
 
 import { createAuthClient } from "better-auth/react";
-import { organizationClient } from "better-auth/client/plugins";
 
+import { getAppOrigin } from "@/lib/utils";
+
+/**
+ * Thin better-auth client used only for authentication flows
+ * (sign-in / sign-up / sign-out). All organization operations go through
+ * the typed Hono RPC at `@/lib/api` so there is a single server boundary.
+ */
 export const authClient = createAuthClient({
-  baseURL:
-    typeof window !== "undefined"
-      ? window.location.origin
-      : process.env.NEXT_PUBLIC_APP_URL,
-  plugins: [organizationClient()],
+  baseURL: getAppOrigin(),
 });
 
-export const {
-  signIn,
-  signUp,
-  signOut,
-  useSession,
-  useListOrganizations,
-  useActiveOrganization,
-  organization,
-} = authClient;
+export const { signIn, signUp, signOut } = authClient;

--- a/src/server/routers/servers.ts
+++ b/src/server/routers/servers.ts
@@ -5,8 +5,15 @@ import { Prisma } from "@prisma/client";
 
 import type { Env } from "../context";
 import { requireOrg } from "../guards";
-import { createServerSchema, updateServerSchema } from "@/lib/schemas";
+import {
+  createServerSchema,
+  quickCreateServerSchema,
+  updateServerSchema,
+} from "@/lib/schemas";
 import { compileOpenApiToTools } from "@/server/mcp/from-openapi";
+import { parseOpenApi } from "@/server/mcp/parse-openapi";
+import { sha256Hex } from "@/lib/crypto";
+import { looksLikeUrl, randomSuffix, slugCandidates, slugify } from "@/lib/utils";
 
 export const serversRouter = new Hono<Env>()
   .use("*", requireOrg)
@@ -82,6 +89,124 @@ export const serversRouter = new Hono<Env>()
     }
   })
 
+  /**
+   * One-shot ingest + server creation. Accepts either a URL or a raw
+   * OpenAPI document (JSON/YAML) in a single string field. Auto-derives
+   * name, slug, and baseUrl from the spec; defaults visibility to PUBLIC
+   * so the MCP endpoint works immediately without a bearer token.
+   */
+  .post("/quick-create", zValidator("json", quickCreateServerSchema), async (c) => {
+    const { input } = c.req.valid("json");
+    const orgId = c.var.orgId!;
+    const userId = c.var.session!.user.id;
+
+    const trimmed = input.trim();
+    if (!trimmed) throw new HTTPException(400, { message: "Empty input." });
+
+    // 1. Resolve input → raw OpenAPI text.
+    let rawText: string;
+    let sourceKind: "URL" | "PASTE" = "PASTE";
+    let sourceUrl: string | null = null;
+    let originFallback: string | null = null;
+
+    if (looksLikeUrl(trimmed)) {
+      sourceKind = "URL";
+      sourceUrl = trimmed;
+      try {
+        originFallback = new URL(trimmed).origin;
+      } catch {
+        /* handled below */
+      }
+      const res = await fetch(trimmed, { redirect: "follow" });
+      if (!res.ok) {
+        throw new HTTPException(400, {
+          message: `Failed to fetch OpenAPI from URL: ${res.status} ${res.statusText}`,
+        });
+      }
+      rawText = await res.text();
+    } else {
+      rawText = trimmed;
+    }
+
+    // 2. Parse + compile.
+    const doc = await parseOpenApi(rawText);
+    const compiled = compileOpenApiToTools(doc);
+    const normalized = JSON.stringify(doc);
+    const hash = await sha256Hex(normalized);
+
+    // 3. Persist the doc (or reuse the existing hash-matched row).
+    const docRow = await upsertOpenApiDoc(c.var.db, {
+      organizationId: orgId,
+      title: compiled.info.title,
+      version: compiled.info.version,
+      source: sourceKind,
+      sourceUrl,
+      hash,
+      rawJson: doc as Prisma.InputJsonValue,
+    });
+
+    // 4. Resolve a baseUrl. Prefer the compiled one; otherwise fall back
+    // to the URL origin the user pasted (trailing slash stripped).
+    const baseUrl = compiled.info.baseUrl ?? originFallback;
+    if (!baseUrl) {
+      throw new HTTPException(400, {
+        message:
+          "Could not determine a base URL — add a `servers[]` entry to your OpenAPI document.",
+      });
+    }
+
+    // 5. Derive slug; retry with random suffix on collision. The slug is
+    // globally unique (see schema), so same-title specs across different
+    // orgs still need disambiguation.
+    const baseSlug = ensureMinLength(slugify(compiled.info.title), "mcp");
+
+    for (const slug of slugCandidates(baseSlug)) {
+      try {
+        const created = await c.var.db.mcpServer.create({
+          data: {
+            name: compiled.info.title,
+            slug,
+            description: null,
+            baseUrl,
+            visibility: "PUBLIC",
+            organizationId: orgId,
+            openApiDocId: docRow.id,
+            createdById: userId,
+            tools: {
+              create: compiled.tools.map((t) => ({
+                name: t.name,
+                operationId: t.operationId ?? null,
+                method: t.method,
+                path: t.path,
+                summary: t.summary ?? null,
+                description: t.description ?? null,
+                inputSchema: t.inputSchema as unknown as Prisma.InputJsonValue,
+                outputSchema: (t.outputSchema ?? null) as Prisma.InputJsonValue,
+                wire: t.wire as unknown as Prisma.InputJsonValue,
+                securityKeys: t.securityKeys,
+                enabled: true,
+              })),
+            },
+          },
+          select: { id: true, slug: true, name: true },
+        });
+        return c.json({ server: created, toolCount: compiled.tools.length }, 201);
+      } catch (err) {
+        if (
+          err instanceof Prisma.PrismaClientKnownRequestError &&
+          err.code === "P2002"
+        ) {
+          // Slug collision — try the next candidate.
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw new HTTPException(409, {
+      message: "Could not reserve a unique slug. Please retry.",
+    });
+  })
+
   .get("/:serverId", async (c) => {
     const serverId = c.req.param("serverId");
     const orgId = c.var.orgId!;
@@ -134,3 +259,44 @@ export const serversRouter = new Hono<Env>()
   });
 
 export type ServersRouter = typeof serversRouter;
+
+/**
+ * Slug schema requires >=3 chars. If the derived slug is too short
+ * (e.g. a 1-char API name), pad it with a random suffix rather than
+ * rejecting the request.
+ */
+function ensureMinLength(s: string, fallbackPrefix: string): string {
+  const clean = s || "";
+  if (clean.length >= 3) return clean;
+  return `${clean || fallbackPrefix}-${randomSuffix(6)}`;
+}
+
+async function upsertOpenApiDoc(
+  db: import("@prisma/client").PrismaClient,
+  data: {
+    organizationId: string;
+    title: string;
+    version: string;
+    source: "URL" | "PASTE";
+    sourceUrl: string | null;
+    hash: string;
+    rawJson: Prisma.InputJsonValue;
+  }
+) {
+  try {
+    return await db.openApiDoc.create({ data });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      const existing = await db.openApiDoc.findUnique({
+        where: {
+          organizationId_hash: {
+            organizationId: data.organizationId,
+            hash: data.hash,
+          },
+        },
+      });
+      if (existing) return existing;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Closes #51

Final slice of the dashboard refactor. Ships the one-shot quick-create endpoint + single-input wizard and migrates the remaining auth/onboarding forms off the better-auth organization client so the typed Hono RPC becomes the only server boundary for org ops.