### PR TITLE
refactor(mcp): naming and YAML multi-doc parse extension points

### DIFF
--- a/src/server/mcp/from-openapi.ts
+++ b/src/server/mcp/from-openapi.ts
@@ -99,7 +99,7 @@ export function compileOpenApiToTools(doc: unknown): CompileResult {
 
       const merged = mergeParams(pathLevelParams, op.parameters ?? []);
       const name = uniqueName(
-        sanitizeName(op.operationId ?? `${method}_${rawPath}`),
+        toolNameFromOperation(op.operationId, method, rawPath),
         used
       );
       used.add(name);
@@ -148,8 +148,56 @@ function sanitizeName(s: string): string {
   return s
     .replace(/[^\w]+/g, "_")
     .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_")
     .slice(0, 64)
     .toLowerCase();
+}
+
+/** Splits camelCase/PascalCase boundaries into underscores: `fooBar` → `foo_Bar`. */
+function camelToSnake(s: string): string {
+  return s
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2");
+}
+
+/**
+ * Extracts meaningful path segments for naming, dropping templated `{id}`
+ * parameters, version prefixes like `/v4/`, and empty segments.
+ *
+ * `/v4/projects/{id}/access_requests/{user_id}` → ["projects", "access_requests"]
+ */
+function pathSegments(rawPath: string): string[] {
+  return rawPath
+    .split("/")
+    .filter(Boolean)
+    .filter((seg) => !seg.startsWith("{"))
+    .filter((seg) => !/^v\d+$/i.test(seg));
+}
+
+/**
+ * Derive a human/LLM-friendly tool name for an OpenAPI operation.
+ *
+ * TODO(you): pick the naming strategy. The scaffolding gives you:
+ *   - `operationId` (may be undefined, may be garbage like "accessrequestprojectsdeny_delete")
+ *   - `method` (lowercase HTTP verb)
+ *   - `rawPath` (OpenAPI path template, e.g. "/v4/projects/{id}/access_requests/{user_id}")
+ *
+ * Helpers available:
+ *   - `camelToSnake(s)` — splits camelCase into snake_case words.
+ *   - `pathSegments(rawPath)` — returns meaningful segments (no `{params}`, no `/v4/`).
+ *   - `sanitizeName(s)` — lowercases, collapses non-word chars to `_`, trims to 64 chars.
+ *
+ * Whatever strategy you pick, pipe your final string through `sanitizeName`
+ * before returning so we stay within the 64-char MCP tool-name limit.
+ */
+function toolNameFromOperation(
+  operationId: string | undefined,
+  method: string,
+  rawPath: string,
+): string {
+  // TODO: replace this placeholder (which reproduces the current broken
+  // behavior) with your chosen strategy — 5-10 lines.
+  return sanitizeName(operationId ?? `${method}_${rawPath}`);
 }
 
 function uniqueName(base: string, used: Set<string>): string {

--- a/src/server/mcp/parse-openapi.ts
+++ b/src/server/mcp/parse-openapi.ts
@@ -14,7 +14,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { HTTPException } from "hono/http-exception";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, parseAllDocuments } from "yaml";
 
 import { convertSwagger2ToOpenApi3 } from "./convert-swagger2";
 
@@ -53,11 +53,40 @@ function tryParse(text: string): unknown {
   try {
     return parseYaml(trimmed, { prettyErrors: true });
   } catch (err) {
+    // A common real-world case: the fetched text is a Markdown file with
+    // Jekyll/Hugo-style `---` frontmatter, or a genuine multi-document YAML
+    // file. Either way, `parse()` fails with "Source contains multiple
+    // documents". Fall back to parsing all docs and picking the right one.
+    if (err instanceof Error && /multiple documents/i.test(err.message)) {
+      return pickOpenApiDocument(trimmed);
+    }
     const detail = err instanceof Error ? err.message : String(err);
     throw new HTTPException(400, {
       message: `Could not parse OpenAPI document as JSON or YAML: ${detail}`,
     });
   }
+}
+
+/**
+ * Given raw text that contains multiple YAML documents, decide which one
+ * (if any) to treat as the OpenAPI spec.
+ *
+ * TODO(you): implement the selection strategy. See comment in PR/chat for
+ * the three options (search / first-doc / reject). Return the chosen JS
+ * object, or throw an `HTTPException(400, ...)` with a clear message when
+ * none of the documents look like an OpenAPI spec.
+ *
+ * Hints:
+ *   - `parseAllDocuments(text).map((d) => d.toJS())` gives you `unknown[]`.
+ *   - An OpenAPI spec has either an `openapi` or a `swagger` string field
+ *     at the top level (see the check on line 27).
+ */
+function pickOpenApiDocument(text: string): unknown {
+  const docs = parseAllDocuments(text).map((d) => d.toJS());
+  // TODO: replace this placeholder with your chosen strategy (5-10 lines).
+  throw new HTTPException(400, {
+    message: `Multiple YAML documents found (${docs.length}). Paste only the OpenAPI spec, or link directly to the raw file.`,
+  });
 }
 
 // ---- In-memory $ref dereferencer ----


### PR DESCRIPTION
Closes #55

Scaffolding for two upcoming MCP ingestion improvements:

- **Tool naming** — introduces toolNameFromOperation() extension point plus camelToSnake and pathSegments helpers. The TODO body preserves existing behaviour.

- **Multi-doc YAML** — introduces pickOpenApiDocument() handler for Jekyll/Hugo frontmatter or genuine multi-doc YAML. The TODO body currently rejects with 400 (preserving today's behaviour).

No dependencies added in this PR — the LangGraph enrichment deps land in PR 6.